### PR TITLE
Truncate movie descriptions in README rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,7 @@ Inside Envoy is a new documentary for anyone interested in how open source techn
 
 Inside Envoy: the Proxy for the Future gives viewers an inside look at the journey from creation to mass adoption of the insanely popular open source Envoy project, one of the most useful open source projects in the world today.
 
-Envoy was open sourced in the fall of 2016 and quickly gained adoption. In 2017, Envoy joined the Cloud Native Computing Foundation (CNCF). Today, Envoy serves trillions of daily requests and has been adopted by thousands of organizations around the world.
-
-Inside Envoy is the second major film release from Speakeasy Productions, which is leading the way in using the power of film and storytelling to demystify core open source software projects that change how we live, work, and play. 
-
-“Inside Envoy, the Proxy for the Future,” debuted at KubeKon &#43; CloudNativeCon Europe 2023 in Amsterdam.
-
-This film was made possible by technology providers and community leaders including Ambassador Labs, Cloud Native Computing Foundation, Lyft, Solo.io and Tetrate.  
-
-To learn more and view the documentary, please visit the film website https://envoyprojectdocumentary.com 
-
-Follow ENVOYPROXY:
-Twitter: https://twitter.com/EnvoyProxy
-
-
-Follow Speakeasy Productions:
-Twitter: https://twitter.com/Speakeasy_Films
+Envoy was open sourced in the fall of 2016 and quickly gained adoption. In 2017, Envoy joined the Cloud Native Computing Foundation (CNCF). Today, Envoy serves trillions of daily requests and has been adopted by thousands of organizations ...
 
 * Channel:  Speakeasy Productions
 * Duration: 31:50
@@ -52,32 +37,7 @@ Twitter: https://twitter.com/Speakeasy_Films
 
 Ruby on Rails has one of the most faithful communities online, it also has one of the most controversial, rabble-rousing creators out there, Danish programmer, David Heinemeier Hansson. Widely known as DHH, David tells us how Rails went from a crazy idea to one of the most talked-about full-stack frameworks over the course of 20 years. 
 
-Get the whole spill by the people who had a front-row seat to the creation and development of Ruby on Rails. Jeremy Daer, Jason Fried, Tobias Lütke, Jamis Buck, and… DHH tell the tale of Rails. A tale seeped with passion, pushback, and (after Rails 3.0) maturity. 
-
-Check out the home for untold developer stories around open source, careers and all the other cool stuff developers are doing at cult.honeypot.io. 
-
-Honeypot is a developer-focused job platform, on a mission to get developers great jobs. Wanna see what we&#39;re all about? Visit honeypot.io to find a job you love. 
-
-To learn more about Honeypot: https://bit.ly/3SnyYV0 
-
-Follow the cast: 
-David Heinemeier Hansson: https://twitter.com/dhh 
-Jason Fried: https://twitter.com/jasonfried 
-Jeremy Daer: https://twitter.com/bitsweat 
-Jamis Buck: https://twitter.com/jamis 
-Tobias Lütke: https://twitter.com/tobi 
-
-Follow Ruby on Rails:
-YouTube: @railsofficial
-Website: https://rubyonrails.org/
-
-Many people contributed to Ruby on Rails throughout the years and this documentary is just a little slice of that history. You can find full acknowledgements here: https://rubyonrails.org/community 
-
-Follow us: 
-Twitter: https://twitter.com/honeypotio 
-Facebook: https://www.facebook.com/Honeypotio/ 
-LinkedIn: https://www.linkedin.com/company/honeypotio/ 
-Instagram: https://www.instagram.com/honeypot.cult/
+Get the whole spill by the people who had a front-row seat to the creation and development of Ruby on Rails. Jeremy Daer, Jason Fried, Tobias Lütke, Jamis Buck, and… DHH tell the tale of Rails. A tale seeped with passion, pushback, and (after Rails 3.0) maturity. ...
 
 * Channel: CultRepo 
 * Duration: 44:16
@@ -95,78 +55,7 @@ Instagram: https://www.instagram.com/honeypot.cult/
 
 Created by Evan You (the mind behind Vue.js), Vite began as a frustrated response to slow build times with Webpack. What started as a personal side project for Vue users quickly grew into a framework-agnostic ecosystem embraced by React, Svelte, Astro, Remix, and more. Along the way, it sparked rivalries, rewrites, and community-driven breakthroughs that changed the frontend landscape forever.
 
-Featuring many prominent developers in the JavaCript ecosystem, this documentary dives into the innovation, competition, and collaboration that turned Vite from an underdog prototype into the new standard for modern web tooling. 
-
-0:00 Intro
-1:00 Early Javascript tooling
-1:53 Webpack explained
-3:40 Evan You discusses frustrations with Webpack
-5:06 Evan You prototypes an alternative
-6:35 First version of Vite is published
-6:57 The Javascript community&#39;s first impressions of Vite
-7:40 Vite vs Snowpack
-8:20 Origin story of SVite
-9:25 Evan begins work on Vite 2.0
-13:50 Vite 2.0 first reactions and early adopters 
-15:42 Stackblitz gets behind Vite
-16:39 Sveltekit backs Snowpack
-18:47 Sveltekit makes controversial switch from Snowpack to Vite
-20:21 Astro adopts Vite
-20:50 Evan You assembles the Vite team
-22:02 Vitest 
-24:25 The Vite team grows
-26:08 Vite adoption explodes
-26:52 Theo Browne vs Create React App
-27:46 The first ViteConf
-29:40 Vite ecosystem CI
-32:26 Remix adopts Vite
-34:25 Major Vite adoptions in 2023
-34:59 David Cramer on Vite growth
-35:31 Vite on Bolt . new
-36:16 Evan You founds Void Zero
-36:58 The future of Vite and the Javascript ecosystem 
-38:51 Credits
-
-Director: Josiah McGarvie
-Producer: Guillermo López
-
-Produced by: Tech Documentaries (www.techdocumentaries.com)
-
-Thanks to our sponsors for making this documentary possible:
-VoidZero (https://voidzero.dev)
-Sentry (www.sentry.io)
-Shopify (www.shopify.com)
-Bolt.new (www.bolt.new)
-Supabase (www.supabase.com)
-
-And to all the amazing people who are featured:
-Evan You: x.com/youyuxi
-Matias Capeletto: bsky.app/profile/patak.dev
-Anthony Fu: x.com/antfu7
-Rich Harris: bsky.app/profile/rich-harris.dev
-Ryan Carniato: x.com/RyanCarniato
-Fred K. Schott: x.com/FredKSchott
-Pedro Cattori: x.com/pcattori
-Mark Dalgleish: x.com/markdalgleish
-Mishko Havery: /x.com/mhevery
-Eric Simons: x.com/EricSimons
-David Cramer: x.com/zeeg
-Theo Brown: x.com/theo
-Bjorn Lu: bsky.app/profile/bluwy.me
-Dominik Göpel
-Vladimir Sheremet
-
-Some podcasts featuring Evan You chatting about Vite and the documentary:
-FreeCodeCamp: https://youtu.be/xH9ZKsTY73Y?si=p6CvmW7lvUwm2LGT
-Stack Overflow: https://stackoverflow.blog/2025/10/10/vite-is-like-the-united-nations-of-javascript/
-Changelog: https://youtu.be/-vi0_b7Aj64?si=chNguLXBkhITw5uv
-Syntax: https://youtu.be/quEc5ZI3_Ys?si=QleHFZ-HcB0LUf6H
-
-
-Follow us:
-X: x.com/CultRepo
-Bluesky: cultrepo.bsky.social
-Instagram: www.instagram.com/cult.repo
+Featuring many prominent developers in the JavaCript ecosystem, this documentary dives into the innovation, competition, and collaboration ...
 
 * Channel: CultRepo 
 * Duration: 39:15

--- a/app/cmd/convertJsonToReadme.go
+++ b/app/cmd/convertJsonToReadme.go
@@ -106,7 +106,7 @@ func cmdConvertJsonToReadme(cmd *cobra.Command, args []string) error {
 	log.Printf("Render template and write it into %s (description max length %d runes) ...", readmeOutput, descriptionMaxLength)
 	funcs := template.FuncMap{
 		"truncateDescription": func(s string) string {
-			return utils.TruncateDescription(s, descriptionMaxLength)
+			return utils.TruncateTextRespectWords(s, descriptionMaxLength)
 		},
 	}
 	t := template.Must(template.New("readme-template").Funcs(funcs).Parse(string(readmeTemplateContent)))

--- a/app/cmd/convertJsonToReadme.go
+++ b/app/cmd/convertJsonToReadme.go
@@ -12,7 +12,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/EngineeringKiosk/awesome-software-engineering-movies/io"
+	"github.com/EngineeringKiosk/awesome-software-engineering-movies/utils"
 )
+
+const defaultDescriptionMaxLength = 600
 
 // convertJsonToReadmeCmd represents the convertJsonToReadme command
 var convertJsonToReadmeCmd = &cobra.Command{
@@ -33,6 +36,7 @@ func init() {
 	convertJsonToReadmeCmd.Flags().String("json-directory", "", "Directory on where to store the json files")
 	convertJsonToReadmeCmd.Flags().String("readme-template", "", "Path to the README template")
 	convertJsonToReadmeCmd.Flags().String("readme-output", "", "Path to the README file that will be written")
+	convertJsonToReadmeCmd.Flags().Int("description-max-length", defaultDescriptionMaxLength, "Maximum length of the rendered description in runes; longer descriptions are cut at the next word or sentence boundary")
 
 	for _, name := range []string{"json-directory", "readme-template", "readme-output"} {
 		if err := convertJsonToReadmeCmd.MarkFlagRequired(name); err != nil {
@@ -52,6 +56,10 @@ func cmdConvertJsonToReadme(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	jsonDir, err := cmd.Flags().GetString("json-directory")
+	if err != nil {
+		return err
+	}
+	descriptionMaxLength, err := cmd.Flags().GetInt("description-max-length")
 	if err != nil {
 		return err
 	}
@@ -95,8 +103,13 @@ func cmdConvertJsonToReadme(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = readmeTarget.Close() }()
 
-	log.Printf("Render template and write it into %s ...", readmeOutput)
-	t := template.Must(template.New("readme-template").Parse(string(readmeTemplateContent)))
+	log.Printf("Render template and write it into %s (description max length %d runes) ...", readmeOutput, descriptionMaxLength)
+	funcs := template.FuncMap{
+		"truncateDescription": func(s string) string {
+			return utils.TruncateDescription(s, descriptionMaxLength)
+		},
+	}
+	t := template.Must(template.New("readme-template").Funcs(funcs).Parse(string(readmeTemplateContent)))
 	if err := t.Execute(readmeTarget, movies); err != nil {
 		return err
 	}

--- a/app/utils/template.go
+++ b/app/utils/template.go
@@ -9,7 +9,7 @@ import (
 	"unicode"
 )
 
-// TruncateDescription returns s shortened to roughly max runes,
+// TruncateTextRespectWords returns s shortened to roughly max runes,
 // respecting word and sentence boundaries.
 //
 // Behaviour:
@@ -25,7 +25,7 @@ import (
 //
 // The function works on runes, not bytes, so multibyte content
 // (emojis, accented characters) counts intuitively.
-func TruncateDescription(s string, max int) string {
+func TruncateTextRespectWords(s string, max int) string {
 	if max <= 0 {
 		return s
 	}

--- a/app/utils/template.go
+++ b/app/utils/template.go
@@ -1,0 +1,75 @@
+// Package utils contains small, reusable helpers for the template
+// rendering pipeline. Functions here are pure (no I/O, no global
+// state) so they can be safely registered as template FuncMap
+// entries and unit tested in isolation.
+package utils
+
+import (
+	"strings"
+	"unicode"
+)
+
+// TruncateDescription returns s shortened to roughly max runes,
+// respecting word and sentence boundaries.
+//
+// Behaviour:
+//   - If s has at most max runes, it is returned unchanged.
+//   - If the rune at position max is a space or the previous rune
+//     is a sentence terminator (. ! ?), the cut happens there.
+//   - Otherwise the function scans forward from position max for
+//     the next space or sentence terminator. A terminator is
+//     included in the cut; whitespace is excluded.
+//   - The result has trailing whitespace trimmed and " ..." appended.
+//   - If no boundary is found before the end of s (one giant word),
+//     s is returned unchanged — better than a hard mid-word cut.
+//
+// The function works on runes, not bytes, so multibyte content
+// (emojis, accented characters) counts intuitively.
+func TruncateDescription(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+
+	cut := findCut(runes, max)
+	if cut < 0 {
+		return s
+	}
+
+	truncated := strings.TrimRightFunc(string(runes[:cut]), unicode.IsSpace)
+	return truncated + " ..."
+}
+
+// findCut returns the index (exclusive) at which to slice runes,
+// or -1 if no acceptable boundary exists.
+func findCut(runes []rune, max int) int {
+	// Boundary already at position max?
+	if isSpace(runes[max]) {
+		return max
+	}
+	if max > 0 && isSentenceEnd(runes[max-1]) {
+		return max
+	}
+
+	// Scan forward for the next boundary.
+	for i := max; i < len(runes); i++ {
+		if isSentenceEnd(runes[i]) {
+			return i + 1 // include the terminator
+		}
+		if isSpace(runes[i]) {
+			return i // exclude the whitespace
+		}
+	}
+	return -1
+}
+
+func isSpace(r rune) bool {
+	return unicode.IsSpace(r)
+}
+
+func isSentenceEnd(r rune) bool {
+	return r == '.' || r == '!' || r == '?'
+}

--- a/app/utils/template_test.go
+++ b/app/utils/template_test.go
@@ -1,0 +1,110 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTruncateDescription(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			max:  10,
+			want: "",
+		},
+		{
+			name: "shorter than max",
+			in:   "hello",
+			max:  10,
+			want: "hello",
+		},
+		{
+			name: "exactly max",
+			in:   "hello world",
+			max:  11,
+			want: "hello world",
+		},
+		{
+			name: "boundary at space",
+			in:   "hello world how are you",
+			max:  5,
+			want: "hello ...",
+		},
+		{
+			name: "mid-word cut advances to next space",
+			in:   "hello beautiful world",
+			max:  8, // mid 'beautiful'
+			want: "hello beautiful ...",
+		},
+		{
+			name: "mid-word cut advances to sentence end",
+			in:   "hello beautiful. world",
+			max:  8, // mid 'beautiful'; period comes before next space
+			want: "hello beautiful. ...",
+		},
+		{
+			name: "previous rune is sentence terminator",
+			in:   "Wow! Another sentence here.",
+			max:  4, // cut after the '!'
+			want: "Wow! ...",
+		},
+		{
+			name: "exclamation in mid-word lookahead",
+			in:   "no boundary yet wait! more",
+			max:  18, // mid 'wait'
+			want: "no boundary yet wait! ...",
+		},
+		{
+			name: "first boundary wins (space before next sentence end)",
+			in:   "is this thing on? yes it is",
+			max:  10, // mid 'thing'; next boundary is the space after 'thing'
+			want: "is this thing ...",
+		},
+		{
+			name: "trims trailing whitespace before ellipsis",
+			in:   "hello   world",
+			max:  5,
+			want: "hello ...",
+		},
+		{
+			name: "single giant word returns unchanged",
+			in:   strings.Repeat("a", 50),
+			max:  10,
+			want: strings.Repeat("a", 50),
+		},
+		{
+			name: "multibyte / emoji counted as runes",
+			// 6 runes: "héllo👋"; max 5 should cut, no boundary inside
+			in:   "héllo👋 world",
+			max:  5, // mid; rune 5 is the emoji
+			want: "héllo👋 ...",
+		},
+		{
+			name: "max zero returns input unchanged",
+			in:   "anything",
+			max:  0,
+			want: "anything",
+		},
+		{
+			name: "negative max returns input unchanged",
+			in:   "anything",
+			max:  -1,
+			want: "anything",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TruncateDescription(tc.in, tc.max)
+			if got != tc.want {
+				t.Fatalf("TruncateDescription(%q, %d)\n  got:  %q\n  want: %q", tc.in, tc.max, got, tc.want)
+			}
+		})
+	}
+}

--- a/app/utils/template_test.go
+++ b/app/utils/template_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestTruncateDescription(t *testing.T) {
+func TestTruncateTextRespectWords(t *testing.T) {
 	cases := []struct {
 		name string
 		in   string
@@ -101,9 +101,9 @@ func TestTruncateDescription(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := TruncateDescription(tc.in, tc.max)
+			got := TruncateTextRespectWords(tc.in, tc.max)
 			if got != tc.want {
-				t.Fatalf("TruncateDescription(%q, %d)\n  got:  %q\n  want: %q", tc.in, tc.max, got, tc.want)
+				t.Fatalf("TruncateTextRespectWords(%q, %d)\n  got:  %q\n  want: %q", tc.in, tc.max, got, tc.want)
 			}
 		})
 	}

--- a/assets/README.template
+++ b/assets/README.template
@@ -17,7 +17,7 @@ A curated list of movies, documentaries and other related material to watch rela
 {{ if $movie.Image }}
 <img align="right" width="320" src="./generated/{{ $movie.Image }}" alt="{{ $movie.Name }}" />
 {{ end }}
-{{ $movie.Description }}
+{{ truncateDescription $movie.Description }}
 
 {{ if $movie.Channel.Title }}* Channel: {{ $movie.Channel.Title }}
 {{ end -}}


### PR DESCRIPTION
## Summary

YouTube descriptions are often paragraphs of trailing socials,
sponsor lists, and boilerplate. The current README emits them
verbatim, which makes the rendered list hard to scan.

This PR adds a `truncateDescription` template function that shortens
each description to a configurable max length while respecting word
and sentence boundaries.

## Behaviour

- New `--description-max-length` flag on `convertJsonToReadme`,
  default **600 runes**.
- Algorithm operates on runes (so emojis and accented characters
  count intuitively):
  - If the description is at most `max` runes, returned unchanged.
  - If position `max` already lands on a word/sentence boundary,
    cut there.
  - Otherwise scan forward for the next space or `.` `!` `?` —
    whichever comes first wins. Sentence terminators are included
    in the cut; whitespace is excluded.
  - Trailing whitespace trimmed; `" ..."` appended.
  - Single giant word with no boundary returns the input unchanged
    rather than producing a hard mid-word cut.

The function lives in a new `app/utils/template.go` (per
maintainer's request) so future template helpers have an obvious
home. It is exposed to the template via a closure registered on
the FuncMap by `convertJsonToReadme`, so the template stays
oblivious to runtime configuration.

## Files changed

- `app/utils/template.go` — new package + function (~80 lines)
- `app/utils/template_test.go` — 14 table-driven cases
- `app/cmd/convertJsonToReadme.go` — flag wiring + FuncMap
- `assets/README.template` — `{{ truncateDescription $movie.Description }}`
- `README.md` — regenerated; the three seed entries lose ~70 lines
  of socials/sponsor copy

## Decisions worth flagging

- The CI workflows (`movie-data.yml`, `render-readme.yml`) do not
  pass `--description-max-length`. The default of 600 is what we
  want; we can wire the flag through later if a different value is
  needed.

## Test plan

- [ ] `Testing` workflow passes
- [ ] `YAML lint` workflow passes
- [ ] `Render README` workflow passes (proves the FuncMap wiring
      works end-to-end on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)