### PR TITLE
Render duration as approximate "ca. X min." in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Inside Envoy: the Proxy for the Future gives viewers an inside look at the journ
 Envoy was open sourced in the fall of 2016 and quickly gained adoption. In 2017, Envoy joined the Cloud Native Computing Foundation (CNCF). Today, Envoy serves trillions of daily requests and has been adopted by thousands of organizations ...
 
 * Channel:  Speakeasy Productions
-* Duration: 31:50
+* Duration: ca. 32 min.
 * Language: en
 * Tags: Networking, Service Mesh, Open Source, Cloud Native
 * [Watch on YouTube](https://www.youtube.com/watch?v=uaksVVHDhYU)
@@ -40,7 +40,7 @@ Ruby on Rails has one of the most faithful communities online, it also has one o
 Get the whole spill by the people who had a front-row seat to the creation and development of Ruby on Rails. Jeremy Daer, Jason Fried, Tobias Lütke, Jamis Buck, and… DHH tell the tale of Rails. A tale seeped with passion, pushback, and (after Rails 3.0) maturity. ...
 
 * Channel: CultRepo 
-* Duration: 44:16
+* Duration: ca. 44 min.
 * Language: en
 * Tags: Web Frameworks, Ruby, Open Source, History
 * [Watch on YouTube](https://www.youtube.com/watch?v=HDKUEXBF3B4)
@@ -58,7 +58,7 @@ Created by Evan You (the mind behind Vue.js), Vite began as a frustrated respons
 Featuring many prominent developers in the JavaCript ecosystem, this documentary dives into the innovation, competition, and collaboration ...
 
 * Channel: CultRepo 
-* Duration: 39:15
+* Duration: ca. 39 min.
 * Language: en
 * Tags: Frontend, Build Tools, JavaScript, Open Source
 * [Watch on YouTube](https://www.youtube.com/watch?v=bmWQqAKLgT4)

--- a/app/cmd/types.go
+++ b/app/cmd/types.go
@@ -48,22 +48,37 @@ func (m *MovieInformation) LanguagesAsList() string {
 	return strings.Join(m.Language, ", ")
 }
 
-// DurationHumanReadable converts the ISO-8601 duration into a compact
-// "H:MM:SS" or "M:SS" string suitable for the README. Returns the
-// raw value back if parsing fails so the README still renders.
+// DurationHumanReadable converts the ISO-8601 duration into an
+// approximate, scannable form for the README. Seconds are dropped
+// (used only for rounding); the result is prefixed with "ca." and
+// suffixed with "min." (with a "h" hour segment when applicable):
+//
+//	PT31M50S    → "ca. 32 min."
+//	PT45S       → "ca. 1 min."
+//	PT2H        → "ca. 2 h 0 min."
+//	PT1H23M45S  → "ca. 1 h 24 min."
+//
+// Returns the raw value back if parsing fails so the README still
+// renders.
 func (m *MovieInformation) DurationHumanReadable() string {
 	d, err := parseISO8601Duration(m.Duration)
 	if err != nil {
 		return m.Duration
 	}
-	totalSeconds := int(d.Seconds())
-	h := totalSeconds / 3600
-	mm := (totalSeconds % 3600) / 60
-	s := totalSeconds % 60
-	if h > 0 {
-		return fmt.Sprintf("%d:%02d:%02d", h, mm, s)
+
+	// Round to nearest minute. Anything > 0 but < 30 s rounds up to
+	// 1 min so we never render the meaningless "ca. 0 min."
+	totalMinutes := int((d + 30*time.Second) / time.Minute)
+	if totalMinutes == 0 && d > 0 {
+		totalMinutes = 1
 	}
-	return fmt.Sprintf("%d:%02d", mm, s)
+
+	hours := totalMinutes / 60
+	minutes := totalMinutes % 60
+	if hours > 0 {
+		return fmt.Sprintf("ca. %d h %d min.", hours, minutes)
+	}
+	return fmt.Sprintf("ca. %d min.", minutes)
 }
 
 // parseISO8601Duration parses the YouTube duration format. It only

--- a/app/cmd/types_test.go
+++ b/app/cmd/types_test.go
@@ -7,14 +7,28 @@ func TestDurationHumanReadable(t *testing.T) {
 		in   string
 		want string
 	}{
-		{"PT43M22S", "43:22"},
-		{"PT1H23M45S", "1:23:45"},
-		{"PT2H", "2:00:00"},
-		{"PT45S", "0:45"},
-		{"PT0S", "0:00"},
-		{"", ""},               // returns raw on parse error
-		{"garbage", "garbage"}, // returns raw on parse error
-		{"PT10H30M", "10:30:00"},
+		// Seconds round up at 30+
+		{"PT31M50S", "ca. 32 min."},
+		{"PT43M22S", "ca. 43 min."},
+		// Seconds round down below 30
+		{"PT43M29S", "ca. 43 min."},
+		{"PT43M30S", "ca. 44 min."},
+
+		// Hour-spanning videos render as "h ... min."
+		{"PT1H23M45S", "ca. 1 h 24 min."},
+		{"PT2H", "ca. 2 h 0 min."},
+		{"PT10H30M", "ca. 10 h 30 min."},
+
+		// Sub-1-minute always renders as "ca. 1 min." rather than 0
+		{"PT45S", "ca. 1 min."},
+		{"PT1S", "ca. 1 min."},
+
+		// Genuinely zero stays zero
+		{"PT0S", "ca. 0 min."},
+
+		// Parse errors return the raw value so the README still renders
+		{"", ""},
+		{"garbage", "garbage"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Replaces the colon-separated `M:SS` / `H:MM:SS` duration format
with a scannable approximate form. Seconds were precise but
irrelevant to the reader's actual question ("coffee-break or deep
dive?"), so they are now used only for rounding.

| ISO-8601 input | Old | New |
|---|---|---|
| `PT31M50S` | `31:50` | `ca. 32 min.` |
| `PT43M22S` | `43:22` | `ca. 43 min.` |
| `PT45S`    | `0:45` | `ca. 1 min.` |
| `PT2H`     | `2:00:00` | `ca. 2 h 0 min.` |
| `PT1H23M45S` | `1:23:45` | `ca. 1 h 24 min.` |

### Rounding rules

- `>= 30 s` of leftover seconds rounds up.
- Anything `> 0` but `< 30 s` still renders as `ca. 1 min.` (we
  never show the meaningless `ca. 0 min.`).
- `PT0S` keeps rendering as `ca. 0 min.`.
- Parse errors keep returning the raw ISO-8601 string so the README
  always renders.

### Files changed

- `app/cmd/types.go` — `DurationHumanReadable()` rewritten
- `app/cmd/types_test.go` — 12 cases covering the new format,
  rounding boundaries, sub-1-min handling, hour-spanning videos,
  and parse-error fallback
- `README.md` — three seed entries flipped to the new format

## Test plan

- [ ] `Testing` workflow passes
- [ ] `Render README` workflow passes
- [ ] `YAML lint` workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)