### PR TITLE
Drop Channel line from README rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Inside Envoy: the Proxy for the Future gives viewers an inside look at the journ
 
 Envoy was open sourced in the fall of 2016 and quickly gained adoption. In 2017, Envoy joined the Cloud Native Computing Foundation (CNCF). Today, Envoy serves trillions of daily requests and has been adopted by thousands of organizations ...
 
-* Channel:  Speakeasy Productions
 * Duration: ca. 32 min.
 * Language: en
 * Tags: Networking, Service Mesh, Open Source, Cloud Native
@@ -39,7 +38,6 @@ Ruby on Rails has one of the most faithful communities online, it also has one o
 
 Get the whole spill by the people who had a front-row seat to the creation and development of Ruby on Rails. Jeremy Daer, Jason Fried, Tobias Lütke, Jamis Buck, and… DHH tell the tale of Rails. A tale seeped with passion, pushback, and (after Rails 3.0) maturity. ...
 
-* Channel: CultRepo 
 * Duration: ca. 44 min.
 * Language: en
 * Tags: Web Frameworks, Ruby, Open Source, History
@@ -57,7 +55,6 @@ Created by Evan You (the mind behind Vue.js), Vite began as a frustrated respons
 
 Featuring many prominent developers in the JavaCript ecosystem, this documentary dives into the innovation, competition, and collaboration ...
 
-* Channel: CultRepo 
 * Duration: ca. 39 min.
 * Language: en
 * Tags: Frontend, Build Tools, JavaScript, Open Source

--- a/assets/README.template
+++ b/assets/README.template
@@ -19,8 +19,6 @@ A curated list of movies, documentaries and other related material to watch rela
 {{ end }}
 {{ truncateDescription $movie.Description }}
 
-{{ if $movie.Channel.Title }}* Channel: {{ $movie.Channel.Title }}
-{{ end -}}
 {{ if $movie.Duration }}* Duration: {{ $movie.DurationHumanReadable }}
 {{ end -}}
 {{ if $movie.Language }}* Language: {{ $movie.LanguagesAsList }}


### PR DESCRIPTION
## Summary

Removes the per-entry `* Channel: …` line from the rendered
README. The channel data is still collected by `collectMovieData`
and persisted to `generated/*.json` under the `channel` object, so
any future rendering or downstream consumer (the webpage repo) can
still use it — only the README emit is suppressed.

### Why

The channel name is rarely the deciding factor for whether to watch
a documentary, and surfacing it pushed the more useful
duration/language/tags lines further down. Each entry is now one
row shorter.

### Files changed

- `assets/README.template` — drop the `* Channel: …` block
- `README.md` — three regenerated entries lose the Channel line

## Test plan

- [ ] `Render README` workflow passes (proves the template still
      renders cleanly without the block)
- [ ] `Testing` workflow passes
- [ ] `YAML lint` workflow passes
- [ ] Confirm `generated/*.json` still carry `channel.id` and
      `channel.title` (untouched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)