### PR TITLE
Add 18 new movie entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,86 @@ A curated list of movies, documentaries and other related material to watch rela
 
 ## Table of Contents
 
-* [Movies](#movies) (3 entries)
+* [Movies](#movies) (21 entries)
+  * [Angular: The Documentary](#angular-the-documentary)
+  * [Clojure: The Documentary](#clojure-the-documentary)
+  * [eBPF: Unlocking the Kernel](#ebpf-unlocking-the-kernel)
+  * [Elixir: The Documentary](#elixir-the-documentary)
+  * [Ember.js: The Documentary](#ember-js-the-documentary)
+  * [GraphQL: The Documentary](#graphql-the-documentary)
   * [Inside Envoy: The Proxy for the Future](#inside-envoy-the-proxy-for-the-future)
+  * [IntelliJ IDEA: The Documentary](#intellij-idea-the-documentary)
+  * [Internet Relay Chat (IRC)](#internet-relay-chat-irc)
+  * [Kubernetes: The Documentary [PART 1]](#kubernetes-the-documentary-part-1)
+  * [Kubernetes: The Documentary [PART 2]](#kubernetes-the-documentary-part-2)
+  * [Laravel Origins: A PHP Documentary](#laravel-origins-a-php-documentary)
+  * [Node.js: The Documentary](#node-js-the-documentary)
+  * [Prometheus: The Documentary](#prometheus-the-documentary)
+  * [Python: The Documentary](#python-the-documentary)
+  * [React.js: The Documentary](#react-js-the-documentary)
   * [Ruby on Rails: The Documentary](#ruby-on-rails-the-documentary)
+  * [Svelte Origins: A JavaScript Documentary](#svelte-origins-a-javascript-documentary)
+  * [TypeScript Origins: The Documentary](#typescript-origins-the-documentary)
   * [VITE: The Documentary](#vite-the-documentary)
+  * [Vue.js: The Documentary](#vue-js-the-documentary)
 * [How to contribute](#how-to-contribute)
 
 ## Movies
 
+
+<h3 id="angular-the-documentary">Angular: The Documentary</h3>
+
+
+
+* Tags: Frontend, JavaScript, Google, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=cRC9DlH45lA)
+
+----
+
+<h3 id="clojure-the-documentary">Clojure: The Documentary</h3>
+
+
+
+* Tags: Programming Languages, Functional Programming, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=Y24vK_QDLFg)
+
+----
+
+<h3 id="ebpf-unlocking-the-kernel">eBPF: Unlocking the Kernel</h3>
+
+
+
+* Tags: Linux, Kernel, Open Source, Networking
+* [Watch on YouTube](https://www.youtube.com/watch?v=Wb_vD3XZYOA)
+
+----
+
+<h3 id="elixir-the-documentary">Elixir: The Documentary</h3>
+
+
+
+* Tags: Programming Languages, Functional Programming, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=lxYFOM3UJzo)
+
+----
+
+<h3 id="ember-js-the-documentary">Ember.js: The Documentary</h3>
+
+
+
+* Tags: Frontend, JavaScript, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=Cvz-9ccflKQ)
+
+----
+
+<h3 id="graphql-the-documentary">GraphQL: The Documentary</h3>
+
+
+
+* Tags: API, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=783ccP__No8)
+
+----
 
 <h3 id="inside-envoy-the-proxy-for-the-future">Inside Envoy: The Proxy for the Future</h3>
 
@@ -30,6 +102,87 @@ Envoy was open sourced in the fall of 2016 and quickly gained adoption. In 2017,
 
 ----
 
+<h3 id="intellij-idea-the-documentary">IntelliJ IDEA: The Documentary</h3>
+
+
+
+* Tags: Developer Tools, IDE, JetBrains, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=Kourq_Lz03U)
+
+----
+
+<h3 id="internet-relay-chat-irc">Internet Relay Chat (IRC)</h3>
+
+
+
+* Tags: Networking, Chat, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=6UbKenFipjo)
+
+----
+
+<h3 id="kubernetes-the-documentary-part-1">Kubernetes: The Documentary [PART 1]</h3>
+
+
+
+* Tags: Cloud Native, Orchestration, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=BE77h7dmoQU)
+
+----
+
+<h3 id="kubernetes-the-documentary-part-2">Kubernetes: The Documentary [PART 2]</h3>
+
+
+
+* Tags: Cloud Native, Orchestration, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=318elIq37PE)
+
+----
+
+<h3 id="laravel-origins-a-php-documentary">Laravel Origins: A PHP Documentary</h3>
+
+
+
+* Tags: Web Frameworks, PHP, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=127ng7botO4)
+
+----
+
+<h3 id="node-js-the-documentary">Node.js: The Documentary</h3>
+
+
+
+* Tags: JavaScript, Backend, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=LB8KwiiUGy0)
+
+----
+
+<h3 id="prometheus-the-documentary">Prometheus: The Documentary</h3>
+
+
+
+* Tags: Observability, Monitoring, Open Source, Cloud Native, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=rT4fJNbfe14)
+
+----
+
+<h3 id="python-the-documentary">Python: The Documentary</h3>
+
+
+
+* Tags: Programming Languages, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=GfH4QL4VqJ0)
+
+----
+
+<h3 id="react-js-the-documentary">React.js: The Documentary</h3>
+
+
+
+* Tags: Frontend, JavaScript, Meta, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=8pDqJVdNa44)
+
+----
+
 <h3 id="ruby-on-rails-the-documentary">Ruby on Rails: The Documentary</h3>
 
 <img align="right" width="320" src="./generated/images/ruby-on-rails-the-documentary.jpg" alt="Ruby on Rails: The Documentary" />
@@ -42,6 +195,24 @@ Get the whole spill by the people who had a front-row seat to the creation and d
 * Language: en
 * Tags: Web Frameworks, Ruby, Open Source, History
 * [Watch on YouTube](https://www.youtube.com/watch?v=HDKUEXBF3B4)
+
+----
+
+<h3 id="svelte-origins-a-javascript-documentary">Svelte Origins: A JavaScript Documentary</h3>
+
+
+
+* Tags: Frontend, JavaScript, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=kMlkCYL9qo0)
+
+----
+
+<h3 id="typescript-origins-the-documentary">TypeScript Origins: The Documentary</h3>
+
+
+
+* Tags: Programming Languages, JavaScript, Microsoft, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=U6s2pdxebSo)
 
 ----
 
@@ -59,6 +230,15 @@ Featuring many prominent developers in the JavaCript ecosystem, this documentary
 * Language: en
 * Tags: Frontend, Build Tools, JavaScript, Open Source
 * [Watch on YouTube](https://www.youtube.com/watch?v=bmWQqAKLgT4)
+
+----
+
+<h3 id="vue-js-the-documentary">Vue.js: The Documentary</h3>
+
+
+
+* Tags: Frontend, JavaScript, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=OrxmtDw4pVI)
 
 ----
 

--- a/generated/angular-the-documentary.json
+++ b/generated/angular-the-documentary.json
@@ -1,0 +1,24 @@
+{
+ "name": "Angular: The Documentary",
+ "slug": "angular-the-documentary",
+ "link": "https://www.youtube.com/watch?v=cRC9DlH45lA",
+ "videoID": "cRC9DlH45lA",
+ "language": null,
+ "tags": [
+  "Frontend",
+  "JavaScript",
+  "Google",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/clojure-the-documentary.json
+++ b/generated/clojure-the-documentary.json
@@ -1,0 +1,23 @@
+{
+ "name": "Clojure: The Documentary",
+ "slug": "clojure-the-documentary",
+ "link": "https://www.youtube.com/watch?v=Y24vK_QDLFg",
+ "videoID": "Y24vK_QDLFg",
+ "language": null,
+ "tags": [
+  "Programming Languages",
+  "Functional Programming",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/ebpf-unlocking-the-kernel.json
+++ b/generated/ebpf-unlocking-the-kernel.json
@@ -1,0 +1,23 @@
+{
+ "name": "eBPF: Unlocking the Kernel",
+ "slug": "ebpf-unlocking-the-kernel",
+ "link": "https://www.youtube.com/watch?v=Wb_vD3XZYOA",
+ "videoID": "Wb_vD3XZYOA",
+ "language": null,
+ "tags": [
+  "Linux",
+  "Kernel",
+  "Open Source",
+  "Networking"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/elixir-the-documentary.json
+++ b/generated/elixir-the-documentary.json
@@ -1,0 +1,23 @@
+{
+ "name": "Elixir: The Documentary",
+ "slug": "elixir-the-documentary",
+ "link": "https://www.youtube.com/watch?v=lxYFOM3UJzo",
+ "videoID": "lxYFOM3UJzo",
+ "language": null,
+ "tags": [
+  "Programming Languages",
+  "Functional Programming",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/ember-js-the-documentary.json
+++ b/generated/ember-js-the-documentary.json
@@ -1,0 +1,23 @@
+{
+ "name": "Ember.js: The Documentary",
+ "slug": "ember-js-the-documentary",
+ "link": "https://www.youtube.com/watch?v=Cvz-9ccflKQ",
+ "videoID": "Cvz-9ccflKQ",
+ "language": null,
+ "tags": [
+  "Frontend",
+  "JavaScript",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/graphql-the-documentary.json
+++ b/generated/graphql-the-documentary.json
@@ -1,0 +1,22 @@
+{
+ "name": "GraphQL: The Documentary",
+ "slug": "graphql-the-documentary",
+ "link": "https://www.youtube.com/watch?v=783ccP__No8",
+ "videoID": "783ccP__No8",
+ "language": null,
+ "tags": [
+  "API",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/intellij-idea-the-documentary.json
+++ b/generated/intellij-idea-the-documentary.json
@@ -1,0 +1,23 @@
+{
+ "name": "IntelliJ IDEA: The Documentary",
+ "slug": "intellij-idea-the-documentary",
+ "link": "https://www.youtube.com/watch?v=Kourq_Lz03U",
+ "videoID": "Kourq_Lz03U",
+ "language": null,
+ "tags": [
+  "Developer Tools",
+  "IDE",
+  "JetBrains",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/internet-relay-chat-irc.json
+++ b/generated/internet-relay-chat-irc.json
@@ -1,0 +1,23 @@
+{
+ "name": "Internet Relay Chat (IRC)",
+ "slug": "internet-relay-chat-irc",
+ "link": "https://www.youtube.com/watch?v=6UbKenFipjo",
+ "videoID": "6UbKenFipjo",
+ "language": null,
+ "tags": [
+  "Networking",
+  "Chat",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/kubernetes-the-documentary-part-1.json
+++ b/generated/kubernetes-the-documentary-part-1.json
@@ -1,0 +1,23 @@
+{
+ "name": "Kubernetes: The Documentary [PART 1]",
+ "slug": "kubernetes-the-documentary-part-1",
+ "link": "https://www.youtube.com/watch?v=BE77h7dmoQU",
+ "videoID": "BE77h7dmoQU",
+ "language": null,
+ "tags": [
+  "Cloud Native",
+  "Orchestration",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/kubernetes-the-documentary-part-2.json
+++ b/generated/kubernetes-the-documentary-part-2.json
@@ -1,0 +1,23 @@
+{
+ "name": "Kubernetes: The Documentary [PART 2]",
+ "slug": "kubernetes-the-documentary-part-2",
+ "link": "https://www.youtube.com/watch?v=318elIq37PE",
+ "videoID": "318elIq37PE",
+ "language": null,
+ "tags": [
+  "Cloud Native",
+  "Orchestration",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/laravel-origins-a-php-documentary.json
+++ b/generated/laravel-origins-a-php-documentary.json
@@ -1,0 +1,23 @@
+{
+ "name": "Laravel Origins: A PHP Documentary",
+ "slug": "laravel-origins-a-php-documentary",
+ "link": "https://www.youtube.com/watch?v=127ng7botO4",
+ "videoID": "127ng7botO4",
+ "language": null,
+ "tags": [
+  "Web Frameworks",
+  "PHP",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/node-js-the-documentary.json
+++ b/generated/node-js-the-documentary.json
@@ -1,0 +1,23 @@
+{
+ "name": "Node.js: The Documentary",
+ "slug": "node-js-the-documentary",
+ "link": "https://www.youtube.com/watch?v=LB8KwiiUGy0",
+ "videoID": "LB8KwiiUGy0",
+ "language": null,
+ "tags": [
+  "JavaScript",
+  "Backend",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/prometheus-the-documentary.json
+++ b/generated/prometheus-the-documentary.json
@@ -1,0 +1,24 @@
+{
+ "name": "Prometheus: The Documentary",
+ "slug": "prometheus-the-documentary",
+ "link": "https://www.youtube.com/watch?v=rT4fJNbfe14",
+ "videoID": "rT4fJNbfe14",
+ "language": null,
+ "tags": [
+  "Observability",
+  "Monitoring",
+  "Open Source",
+  "Cloud Native",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/python-the-documentary.json
+++ b/generated/python-the-documentary.json
@@ -1,0 +1,22 @@
+{
+ "name": "Python: The Documentary",
+ "slug": "python-the-documentary",
+ "link": "https://www.youtube.com/watch?v=GfH4QL4VqJ0",
+ "videoID": "GfH4QL4VqJ0",
+ "language": null,
+ "tags": [
+  "Programming Languages",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/react-js-the-documentary.json
+++ b/generated/react-js-the-documentary.json
@@ -1,0 +1,24 @@
+{
+ "name": "React.js: The Documentary",
+ "slug": "react-js-the-documentary",
+ "link": "https://www.youtube.com/watch?v=8pDqJVdNa44",
+ "videoID": "8pDqJVdNa44",
+ "language": null,
+ "tags": [
+  "Frontend",
+  "JavaScript",
+  "Meta",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/svelte-origins-a-javascript-documentary.json
+++ b/generated/svelte-origins-a-javascript-documentary.json
@@ -1,0 +1,23 @@
+{
+ "name": "Svelte Origins: A JavaScript Documentary",
+ "slug": "svelte-origins-a-javascript-documentary",
+ "link": "https://www.youtube.com/watch?v=kMlkCYL9qo0",
+ "videoID": "kMlkCYL9qo0",
+ "language": null,
+ "tags": [
+  "Frontend",
+  "JavaScript",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/typescript-origins-the-documentary.json
+++ b/generated/typescript-origins-the-documentary.json
@@ -1,0 +1,23 @@
+{
+ "name": "TypeScript Origins: The Documentary",
+ "slug": "typescript-origins-the-documentary",
+ "link": "https://www.youtube.com/watch?v=U6s2pdxebSo",
+ "videoID": "U6s2pdxebSo",
+ "language": null,
+ "tags": [
+  "Programming Languages",
+  "JavaScript",
+  "Microsoft",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/vue-js-the-documentary.json
+++ b/generated/vue-js-the-documentary.json
@@ -1,0 +1,23 @@
+{
+ "name": "Vue.js: The Documentary",
+ "slug": "vue-js-the-documentary",
+ "link": "https://www.youtube.com/watch?v=OrxmtDw4pVI",
+ "videoID": "OrxmtDw4pVI",
+ "language": null,
+ "tags": [
+  "Frontend",
+  "JavaScript",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/movies/angular-the-documentary.yml
+++ b/movies/angular-the-documentary.yml
@@ -1,0 +1,8 @@
+name: "Angular: The Documentary"
+link: https://www.youtube.com/watch?v=cRC9DlH45lA
+tags:
+  - Frontend
+  - JavaScript
+  - Google
+  - Open Source
+  - History

--- a/movies/clojure-the-documentary.yml
+++ b/movies/clojure-the-documentary.yml
@@ -1,0 +1,7 @@
+name: "Clojure: The Documentary"
+link: https://www.youtube.com/watch?v=Y24vK_QDLFg
+tags:
+  - Programming Languages
+  - Functional Programming
+  - Open Source
+  - History

--- a/movies/ebpf-unlocking-the-kernel.yml
+++ b/movies/ebpf-unlocking-the-kernel.yml
@@ -1,0 +1,7 @@
+name: "eBPF: Unlocking the Kernel"
+link: https://www.youtube.com/watch?v=Wb_vD3XZYOA
+tags:
+  - Linux
+  - Kernel
+  - Open Source
+  - Networking

--- a/movies/elixir-the-documentary.yml
+++ b/movies/elixir-the-documentary.yml
@@ -1,0 +1,7 @@
+name: "Elixir: The Documentary"
+link: https://www.youtube.com/watch?v=lxYFOM3UJzo
+tags:
+  - Programming Languages
+  - Functional Programming
+  - Open Source
+  - History

--- a/movies/ember-js-the-documentary.yml
+++ b/movies/ember-js-the-documentary.yml
@@ -1,0 +1,7 @@
+name: "Ember.js: The Documentary"
+link: https://www.youtube.com/watch?v=Cvz-9ccflKQ
+tags:
+  - Frontend
+  - JavaScript
+  - Open Source
+  - History

--- a/movies/graphql-the-documentary.yml
+++ b/movies/graphql-the-documentary.yml
@@ -1,0 +1,6 @@
+name: "GraphQL: The Documentary"
+link: https://www.youtube.com/watch?v=783ccP__No8
+tags:
+  - API
+  - Open Source
+  - History

--- a/movies/intellij-idea-the-documentary.yml
+++ b/movies/intellij-idea-the-documentary.yml
@@ -1,0 +1,7 @@
+name: "IntelliJ IDEA: The Documentary"
+link: https://www.youtube.com/watch?v=Kourq_Lz03U
+tags:
+  - Developer Tools
+  - IDE
+  - JetBrains
+  - History

--- a/movies/internet-relay-chat-irc.yml
+++ b/movies/internet-relay-chat-irc.yml
@@ -1,0 +1,7 @@
+name: Internet Relay Chat (IRC)
+link: https://www.youtube.com/watch?v=6UbKenFipjo
+tags:
+  - Networking
+  - Chat
+  - Open Source
+  - History

--- a/movies/kubernetes-the-documentary-part-1.yml
+++ b/movies/kubernetes-the-documentary-part-1.yml
@@ -1,0 +1,7 @@
+name: "Kubernetes: The Documentary [PART 1]"
+link: https://www.youtube.com/watch?v=BE77h7dmoQU
+tags:
+  - Cloud Native
+  - Orchestration
+  - Open Source
+  - History

--- a/movies/kubernetes-the-documentary-part-2.yml
+++ b/movies/kubernetes-the-documentary-part-2.yml
@@ -1,0 +1,7 @@
+name: "Kubernetes: The Documentary [PART 2]"
+link: https://www.youtube.com/watch?v=318elIq37PE
+tags:
+  - Cloud Native
+  - Orchestration
+  - Open Source
+  - History

--- a/movies/laravel-origins-a-php-documentary.yml
+++ b/movies/laravel-origins-a-php-documentary.yml
@@ -1,0 +1,7 @@
+name: "Laravel Origins: A PHP Documentary"
+link: https://www.youtube.com/watch?v=127ng7botO4
+tags:
+  - Web Frameworks
+  - PHP
+  - Open Source
+  - History

--- a/movies/node-js-the-documentary.yml
+++ b/movies/node-js-the-documentary.yml
@@ -1,0 +1,7 @@
+name: "Node.js: The Documentary"
+link: https://www.youtube.com/watch?v=LB8KwiiUGy0
+tags:
+  - JavaScript
+  - Backend
+  - Open Source
+  - History

--- a/movies/prometheus-the-documentary.yml
+++ b/movies/prometheus-the-documentary.yml
@@ -1,0 +1,8 @@
+name: "Prometheus: The Documentary"
+link: https://www.youtube.com/watch?v=rT4fJNbfe14
+tags:
+  - Observability
+  - Monitoring
+  - Open Source
+  - Cloud Native
+  - History

--- a/movies/python-the-documentary.yml
+++ b/movies/python-the-documentary.yml
@@ -1,0 +1,6 @@
+name: "Python: The Documentary"
+link: https://www.youtube.com/watch?v=GfH4QL4VqJ0
+tags:
+  - Programming Languages
+  - Open Source
+  - History

--- a/movies/react-js-the-documentary.yml
+++ b/movies/react-js-the-documentary.yml
@@ -1,0 +1,8 @@
+name: "React.js: The Documentary"
+link: https://www.youtube.com/watch?v=8pDqJVdNa44
+tags:
+  - Frontend
+  - JavaScript
+  - Meta
+  - Open Source
+  - History

--- a/movies/svelte-origins-a-javascript-documentary.yml
+++ b/movies/svelte-origins-a-javascript-documentary.yml
@@ -1,0 +1,7 @@
+name: "Svelte Origins: A JavaScript Documentary"
+link: https://www.youtube.com/watch?v=kMlkCYL9qo0
+tags:
+  - Frontend
+  - JavaScript
+  - Open Source
+  - History

--- a/movies/typescript-origins-the-documentary.yml
+++ b/movies/typescript-origins-the-documentary.yml
@@ -1,0 +1,7 @@
+name: "TypeScript Origins: The Documentary"
+link: https://www.youtube.com/watch?v=U6s2pdxebSo
+tags:
+  - Programming Languages
+  - JavaScript
+  - Microsoft
+  - History

--- a/movies/vue-js-the-documentary.yml
+++ b/movies/vue-js-the-documentary.yml
@@ -1,0 +1,7 @@
+name: "Vue.js: The Documentary"
+link: https://www.youtube.com/watch?v=OrxmtDw4pVI
+tags:
+  - Frontend
+  - JavaScript
+  - Open Source
+  - History


### PR DESCRIPTION
## Summary

Imports 18 new YouTube documentaries / explainers covering
languages, frameworks, IDEs and infrastructure projects. Each gets
a YAML file under `movies/`, a generated JSON file under
`generated/`, and a regenerated README entry.

### New entries

- Internet Relay Chat (IRC)
- eBPF: Unlocking the Kernel
- Prometheus: The Documentary
- Laravel Origins: A PHP Documentary
- Svelte Origins: A JavaScript Documentary
- TypeScript Origins: The Documentary
- IntelliJ IDEA: The Documentary
- Python: The Documentary
- Angular: The Documentary
- Node.js: The Documentary
- React.js: The Documentary
- Kubernetes: The Documentary [PART 1]
- Kubernetes: The Documentary [PART 2]
- Vue.js: The Documentary
- GraphQL: The Documentary
- Ember.js: The Documentary
- Elixir: The Documentary
- Clojure: The Documentary

### Decisions

- Three pipe-separated supplied titles (Python, React.js, Clojure)
  were shortened to their canonical "X: The Documentary" form so
  the slugs and README anchors stay clean.
- `language` is omitted on all 18. The next `collectMovieData` run
  (once `YOUTUBE_API_KEY` is configured) will populate it from the
  YouTube `defaultAudioLanguage` field. Manual override remains
  available for entries where the API has nothing.
- API-enriched fields (`title`, `description`, `duration`,
  `channel`, `viewCount`, `image`) start empty in the new JSONs;
  the first scheduled `movie-data` run after the secret lands will
  fill them and re-render the README automatically.

## Test plan

- [ ] `Testing` workflow passes
- [ ] `YAML lint` workflow passes (validates all 21 entries)
- [ ] `Render README` workflow passes (proves the template handles
      empty-description entries cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)