### PR TITLE
Add four more culture-and-activism documentaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ A curated list of movies, documentaries and other related material to watch rela
 
 ## Table of Contents
 
-* [Movies](#movies) (22 entries)
+* [Movies](#movies) (26 entries)
   * [Angular: The Documentary](#angular-the-documentary)
   * [Clojure: The Documentary](#clojure-the-documentary)
+  * [CODE: Debugging the Gender Gap](#code-debugging-the-gender-gap)
   * [eBPF: Unlocking the Kernel](#ebpf-unlocking-the-kernel)
   * [Elixir: The Documentary](#elixir-the-documentary)
   * [Ember.js: The Documentary](#ember-js-the-documentary)
@@ -22,11 +23,14 @@ A curated list of movies, documentaries and other related material to watch rela
   * [Prometheus: The Documentary](#prometheus-the-documentary)
   * [Python: The Documentary](#python-the-documentary)
   * [React.js: The Documentary](#react-js-the-documentary)
+  * [Revolution OS](#revolution-os)
   * [Ruby on Rails: The Documentary](#ruby-on-rails-the-documentary)
   * [Svelte Origins: A JavaScript Documentary](#svelte-origins-a-javascript-documentary)
+  * [The Internet&#39;s Own Boy: The Story of Aaron Swartz](#the-internets-own-boy-the-story-of-aaron-swartz)
   * [TypeScript Origins: The Documentary](#typescript-origins-the-documentary)
   * [VITE: The Documentary](#vite-the-documentary)
   * [Vue.js: The Documentary](#vue-js-the-documentary)
+  * [We Are Legion: The Story of the Hacktivists](#we-are-legion-the-story-of-the-hacktivists)
 * [How to contribute](#how-to-contribute)
 
 ## Movies
@@ -66,6 +70,15 @@ Railway is the all-in-one intelligent cloud ...
 * Language: en
 * Tags: Programming Languages, Functional Programming, Open Source, History
 * [Watch on YouTube](https://www.youtube.com/watch?v=Y24vK_QDLFg)
+
+----
+
+<h3 id="code-debugging-the-gender-gap">CODE: Debugging the Gender Gap</h3>
+
+
+
+* Tags: Girls, STEM, Women in Tech
+* [Watch on YouTube](https://www.youtube.com/watch?v=rQKRw6tWsb8)
 
 ----
 
@@ -335,6 +348,15 @@ But what if we told you that React’s first brush with the public sphere was an
 
 ----
 
+<h3 id="revolution-os">Revolution OS</h3>
+
+
+
+* Tags: GNU/Linux, Open Source, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=k0RYQVkQmWU)
+
+----
+
 <h3 id="ruby-on-rails-the-documentary">Ruby on Rails: The Documentary</h3>
 
 <img align="right" width="320" src="./generated/images/ruby-on-rails-the-documentary.jpg" alt="Ruby on Rails: The Documentary" />
@@ -366,6 +388,15 @@ Svelte Origins ...
 * Language: en
 * Tags: Frontend, JavaScript, Open Source, History
 * [Watch on YouTube](https://www.youtube.com/watch?v=kMlkCYL9qo0)
+
+----
+
+<h3 id="the-internets-own-boy-the-story-of-aaron-swartz">The Internet&#39;s Own Boy: The Story of Aaron Swartz</h3>
+
+
+
+* Tags: Hacktivism, Open Internet, Activism, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=9vz06QO3UkQ)
 
 ----
 
@@ -425,6 +456,15 @@ Honeypot is a developer-focused job platform, on a mission to get every develope
 * Language: en
 * Tags: Frontend, JavaScript, Open Source, History
 * [Watch on YouTube](https://www.youtube.com/watch?v=OrxmtDw4pVI)
+
+----
+
+<h3 id="we-are-legion-the-story-of-the-hacktivists">We Are Legion: The Story of the Hacktivists</h3>
+
+
+
+* Tags: Anonymous, Hacktivism, Security, History
+* [Watch on YouTube](https://www.youtube.com/watch?v=4D1WJsdu6W8)
 
 ----
 

--- a/generated/code-debugging-the-gender-gap.json
+++ b/generated/code-debugging-the-gender-gap.json
@@ -1,0 +1,22 @@
+{
+ "name": "CODE: Debugging the Gender Gap",
+ "slug": "code-debugging-the-gender-gap",
+ "link": "https://www.youtube.com/watch?v=rQKRw6tWsb8",
+ "videoID": "rQKRw6tWsb8",
+ "language": null,
+ "tags": [
+  "Girls",
+  "STEM",
+  "Women in Tech"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/revolution-os.json
+++ b/generated/revolution-os.json
@@ -1,0 +1,22 @@
+{
+ "name": "Revolution OS",
+ "slug": "revolution-os",
+ "link": "https://www.youtube.com/watch?v=k0RYQVkQmWU",
+ "videoID": "k0RYQVkQmWU",
+ "language": null,
+ "tags": [
+  "GNU/Linux",
+  "Open Source",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/the-internets-own-boy-aaron-swartz.json
+++ b/generated/the-internets-own-boy-aaron-swartz.json
@@ -1,0 +1,23 @@
+{
+ "name": "The Internet's Own Boy: The Story of Aaron Swartz",
+ "slug": "the-internets-own-boy-the-story-of-aaron-swartz",
+ "link": "https://www.youtube.com/watch?v=9vz06QO3UkQ",
+ "videoID": "9vz06QO3UkQ",
+ "language": null,
+ "tags": [
+  "Hacktivism",
+  "Open Internet",
+  "Activism",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/generated/we-are-legion-the-story-of-the-hacktivists.json
+++ b/generated/we-are-legion-the-story-of-the-hacktivists.json
@@ -1,0 +1,23 @@
+{
+ "name": "We Are Legion: The Story of the Hacktivists",
+ "slug": "we-are-legion-the-story-of-the-hacktivists",
+ "link": "https://www.youtube.com/watch?v=4D1WJsdu6W8",
+ "videoID": "4D1WJsdu6W8",
+ "language": null,
+ "tags": [
+  "Anonymous",
+  "Hacktivism",
+  "Security",
+  "History"
+ ],
+ "title": "",
+ "description": "",
+ "duration": "",
+ "publishedAt": "",
+ "channel": {
+  "id": "",
+  "title": ""
+ },
+ "viewCount": 0,
+ "image": ""
+}

--- a/movies/code-debugging-the-gender-gap.yml
+++ b/movies/code-debugging-the-gender-gap.yml
@@ -1,0 +1,6 @@
+name: "CODE: Debugging the Gender Gap"
+link: https://www.youtube.com/watch?v=rQKRw6tWsb8
+tags:
+  - Girls
+  - STEM
+  - Women in Tech

--- a/movies/revolution-os.yml
+++ b/movies/revolution-os.yml
@@ -1,0 +1,6 @@
+name: Revolution OS
+link: https://www.youtube.com/watch?v=k0RYQVkQmWU
+tags:
+  - GNU/Linux
+  - Open Source
+  - History

--- a/movies/the-internets-own-boy-aaron-swartz.yml
+++ b/movies/the-internets-own-boy-aaron-swartz.yml
@@ -1,0 +1,7 @@
+name: "The Internet's Own Boy: The Story of Aaron Swartz"
+link: https://www.youtube.com/watch?v=9vz06QO3UkQ
+tags:
+  - Hacktivism
+  - Open Internet
+  - Activism
+  - History

--- a/movies/we-are-legion-the-story-of-the-hacktivists.yml
+++ b/movies/we-are-legion-the-story-of-the-hacktivists.yml
@@ -1,0 +1,7 @@
+name: "We Are Legion: The Story of the Hacktivists"
+link: https://www.youtube.com/watch?v=4D1WJsdu6W8
+tags:
+  - Anonymous
+  - Hacktivism
+  - Security
+  - History


### PR DESCRIPTION
## Summary

Stacked on top of #10 (Half-Life). Four entries that broaden the
list beyond the language/framework history slice with
documentaries on internet culture, hacker activism, and
representation in tech.

### New entries

- The Internet's Own Boy: The Story of Aaron Swartz
- CODE: Debugging the Gender Gap (tags supplied: Girls, STEM, Women in Tech)
- Revolution OS (tag supplied: GNU/Linux; added Open Source, History)
- We Are Legion: The Story of the Hacktivists (tag supplied: Anonymous; added Hacktivism, Security, History)

### Note on the supplied description

For "We Are Legion" the maintainer supplied a prose description.
The schema only sources `description` from the YouTube API, so it
is **not stored in the YAML**. The next `collectMovieData` run
will populate `description` from what YouTube returns. If that
turns out to be unhelpful for some entries, we can revisit the
schema to add a manual description override.

`language` is omitted on all four; the API fallback handles it.

## Stacked PR note

Base is `andygrunwald/add-half-life-documentary` (PR #10) so the
diff stays focused on these four entries. Once #10 merges I'll
re-target the base to `main`.

## Test plan

- [ ] `Testing` workflow passes
- [ ] `YAML lint` workflow passes
- [ ] `Render README` workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)