### PR TITLE
Allow optional description override in YAML

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,11 +65,12 @@ channel, view count and thumbnail from the YouTube Data API.
 |------------|----------------|----------|-----------------|-------|
 | `name`     | string         | yes      | YAML            | Drives the slug, filename and README anchor. Keep it close to the YouTube title but cleaned up if needed. |
 | `link`     | string (URL)   | yes      | YAML            | YouTube URL — `youtube.com/watch?v=…`, `youtu.be/…`, `/embed/…`, `/shorts/…` are all accepted. |
-| `language` | list[string]   | no       | YAML > API      | ISO 639-1 codes (`en`, `de`, `fr`, …). If omitted, the tooling falls back to the YouTube `defaultAudioLanguage` and stores it as a single-element list. Set it manually when the API returns nothing or when the video has multiple audio languages. |
-| `tags`     | list[string]   | yes      | YAML            | Subject-matter tags. Be coarse — better to have 3–5 broad tags than 15 narrow ones. |
+| `language`    | list[string]   | no       | YAML > API      | ISO 639-1 codes (`en`, `de`, `fr`, …). If omitted, the tooling falls back to the YouTube `defaultAudioLanguage` and stores it as a single-element list. Set it manually when the API returns nothing or when the video has multiple audio languages. |
+| `description` | string         | no       | YAML > API      | Free text. If omitted, the tooling uses the video's YouTube description. Set it manually when the YouTube description is empty, full of unrelated boilerplate, or otherwise unhelpful for skim-reading the README. |
+| `tags`        | list[string]   | yes      | YAML            | Subject-matter tags. Be coarse — better to have 3–5 broad tags than 15 narrow ones. |
 
-The remaining JSON fields (`title`, `description`, `duration`,
-`publishedAt`, `channel`, `viewCount`, `image`, `slug`, `videoID`)
-are produced by the tooling. **Do not edit `README.md` directly** —
+The remaining JSON fields (`title`, `duration`, `publishedAt`,
+`channel`, `viewCount`, `image`, `slug`, `videoID`) are produced by
+the tooling. **Do not edit `README.md` directly** —
 it is overwritten on every CI run. To change rendering, update
 `assets/README.template`.

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Honeypot is a developer-focused job platform, on a mission to get every develope
 
 <h3 id="we-are-legion-the-story-of-the-hacktivists">We Are Legion: The Story of the Hacktivists</h3>
 
-
+This documentary takes a deep dive into the world of Anonymous, a loosely organized international group of hacktivists. It offers a fascinating look at the power and influence of hacker culture in the digital age.
 
 * Tags: Anonymous, Hacktivism, Security, History
 * [Watch on YouTube](https://www.youtube.com/watch?v=4D1WJsdu6W8)

--- a/app/cmd/collectMovieData.go
+++ b/app/cmd/collectMovieData.go
@@ -133,11 +133,16 @@ func cmdCollectMovieData(cmd *cobra.Command, args []string) error {
 			log.Printf("WARNING: YouTube returned no record for %s (%s); keeping cached values", info.Name, info.VideoID)
 		} else {
 			info.Title = v.Title
-			info.Description = v.Description
 			info.Duration = v.Duration
 			info.PublishedAt = v.PublishedAt
 			info.Channel = v.Channel
 			info.ViewCount = v.ViewCount
+
+			// Description is YAML-overridable: only use the API value
+			// when the YAML left it empty. Same precedence as Language.
+			if len(info.Description) == 0 {
+				info.Description = v.Description
+			}
 
 			// Language is YAML-overridable: only fall back to the
 			// API-declared audio language when the YAML left it empty.

--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -135,15 +135,19 @@ func cmdConvertYamlToJson(cmd *cobra.Command, args []string) error {
 // fields already present in target. If the YAML schema gains new
 // curated fields, they must be added here as well.
 //
-// Language is special: it is optional in YAML. If the YAML omits it
-// we keep whatever target already has (which may be a value
-// previously derived from the YouTube API in collectMovieData), so
-// the YAML acts as an override rather than a forced reset.
+// Language and Description are special: both are optional in YAML.
+// If the YAML omits them we keep whatever target already has (which
+// may be a value previously derived from the YouTube API in
+// collectMovieData), so the YAML acts as an override rather than a
+// forced reset.
 func mergeMovieInformation(source, target *MovieInformation) *MovieInformation {
 	target.Name = source.Name
 	target.Link = source.Link
 	if len(source.Language) > 0 {
 		target.Language = source.Language
+	}
+	if len(source.Description) > 0 {
+		target.Description = source.Description
 	}
 	target.Tags = source.Tags
 	return target

--- a/app/cmd/convertYamlToJson_test.go
+++ b/app/cmd/convertYamlToJson_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import "testing"
+
+// mergeMovieInformation has two override-only fields (Language,
+// Description) whose YAML > API precedence is easy to break by
+// accident on schema changes. These tests pin the contract.
+
+func TestMergeMovieInformation_DescriptionPrecedence(t *testing.T) {
+	t.Run("YAML description overrides target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l", Description: "from-yaml"}
+		json := &MovieInformation{Name: "stale", Link: "stale", Description: "from-api"}
+
+		got := mergeMovieInformation(yaml, json)
+		if got.Description != "from-yaml" {
+			t.Fatalf("Description = %q; want %q", got.Description, "from-yaml")
+		}
+	})
+
+	t.Run("empty YAML description preserves target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l"} // Description empty
+		json := &MovieInformation{Name: "stale", Link: "stale", Description: "from-api"}
+
+		got := mergeMovieInformation(yaml, json)
+		if got.Description != "from-api" {
+			t.Fatalf("Description = %q; want %q (target preserved)", got.Description, "from-api")
+		}
+	})
+}
+
+func TestMergeMovieInformation_LanguagePrecedence(t *testing.T) {
+	t.Run("YAML language overrides target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l", Language: []string{"de"}}
+		json := &MovieInformation{Name: "stale", Link: "stale", Language: []string{"en"}}
+
+		got := mergeMovieInformation(yaml, json)
+		if len(got.Language) != 1 || got.Language[0] != "de" {
+			t.Fatalf("Language = %v; want [de]", got.Language)
+		}
+	})
+
+	t.Run("empty YAML language preserves target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l"} // Language empty
+		json := &MovieInformation{Name: "stale", Link: "stale", Language: []string{"en"}}
+
+		got := mergeMovieInformation(yaml, json)
+		if len(got.Language) != 1 || got.Language[0] != "en" {
+			t.Fatalf("Language = %v; want [en] (target preserved)", got.Language)
+		}
+	})
+}

--- a/app/cmd/types.go
+++ b/app/cmd/types.go
@@ -29,9 +29,13 @@ type MovieInformation struct {
 	Tags     []string `yaml:"tags"     json:"tags"`
 
 	// API-enriched fields below this line.
-	Title       string          `yaml:"-" json:"title"`
-	Description string          `yaml:"-" json:"description"`
-	Duration    string          `yaml:"-" json:"duration"` // ISO-8601, e.g. PT43M22S
+	Title string `yaml:"-" json:"title"`
+	// Description is optional in YAML. If supplied, the YAML value
+	// overrides whatever the YouTube API returns; if omitted, the
+	// API's snippet.description is used. Same precedence rule as
+	// Language.
+	Description string          `yaml:"description,omitempty" json:"description"`
+	Duration    string          `yaml:"-"                     json:"duration"` // ISO-8601, e.g. PT43M22S
 	PublishedAt string          `yaml:"-" json:"publishedAt"`
 	Channel     youtube.Channel `yaml:"-" json:"channel"`
 	ViewCount   int64           `yaml:"-" json:"viewCount"`

--- a/generated/we-are-legion-the-story-of-the-hacktivists.json
+++ b/generated/we-are-legion-the-story-of-the-hacktivists.json
@@ -11,7 +11,7 @@
   "History"
  ],
  "title": "",
- "description": "",
+ "description": "This documentary takes a deep dive into the world of Anonymous, a loosely organized international group of hacktivists. It offers a fascinating look at the power and influence of hacker culture in the digital age.",
  "duration": "",
  "publishedAt": "",
  "channel": {

--- a/movies/we-are-legion-the-story-of-the-hacktivists.yml
+++ b/movies/we-are-legion-the-story-of-the-hacktivists.yml
@@ -1,5 +1,10 @@
 name: "We Are Legion: The Story of the Hacktivists"
 link: https://www.youtube.com/watch?v=4D1WJsdu6W8
+description: >-
+  This documentary takes a deep dive into the world of Anonymous, a
+  loosely organized international group of hacktivists. It offers a
+  fascinating look at the power and influence of hacker culture in
+  the digital age.
 tags:
   - Anonymous
   - Hacktivism


### PR DESCRIPTION
## Summary

Stacked on top of #11. Extends the YAML schema with an optional
`description` field that overrides the YouTube API value when
supplied — same precedence rule already in place for `language`.

Also lands the maintainer-supplied summary for "We Are Legion: The
Story of the Hacktivists" using the new field, so the entry has a
useful description even before the first `collectMovieData` run.

### Three coordinated code changes

The YAML > API precedence is only stable across re-runs when all
three of these line up:

1. **`app/cmd/types.go`** — `Description` gains the
   `yaml:"description,omitempty"` tag. Old YAML files without
   the field still parse fine.
2. **`mergeMovieInformation` in `app/cmd/convertYamlToJson.go`** —
   only overwrites `target.Description` when the YAML carries a
   non-empty value; otherwise keeps whatever was already on the
   JSON (which may be API-derived). Without this guard, an empty
   YAML description would clobber the API value on every
   `convertYamlToJson` re-run.
3. **`collectMovieData` in `app/cmd/collectMovieData.go`** — only
   sets `info.Description` from the API when `info.Description`
   is empty. Without this, the API would clobber a YAML-supplied
   description on every `collectMovieData` re-run.

Both override-and-preserve paths are pinned by table-driven tests
in `app/cmd/convertYamlToJson_test.go` for both `description` and
`language`.

### Doc and data updates

- `CONTRIBUTING.md` — adds the `description` row to the field
  reference table and drops it from the "produced by the tooling"
  sentence.
- `movies/we-are-legion-the-story-of-the-hacktivists.yml` — gains
  a folded-scalar `description: >-` block with the supplied text.
- `generated/we-are-legion-...json` and `README.md` regenerated
  to reflect the change.

## Stacked PR note

Base is `andygrunwald/add-4-more-culture-movies` (PR #11) so the
diff stays focused on the schema work. When #10 → #11 land, this
PR will retarget to `main`.

## Test plan

- [ ] `Testing` workflow passes (new tests cover both
      preservation and override paths)
- [ ] `YAML lint` workflow passes
- [ ] `Render README` workflow passes
- [ ] Verify on the rendered README that the "We Are Legion" entry
      shows the supplied summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)