### PR TITLE
Add subtitles field populated from YouTube captions

### DIFF
--- a/app/cmd/collectMovieData.go
+++ b/app/cmd/collectMovieData.go
@@ -144,15 +144,21 @@ func cmdCollectMovieData(cmd *cobra.Command, args []string) error {
 				info.Description = v.Description
 			}
 
-			// Language is YAML-overridable: only fall back to the
-			// API-declared audio language when the YAML left it empty.
-			if len(info.Language) == 0 {
-				if code := normalizeLanguageCode(v.DefaultAudioLanguage); code != "" {
-					info.Language = []string{code}
-				} else {
-					log.Printf("WARNING: %s has no language in YAML and YouTube did not return defaultAudioLanguage; leaving empty", info.Name)
-				}
+			// Language is YAML-curated and unioned with the API's
+			// defaultAudioLanguage: YAML order is preserved, the API
+			// code is appended only if not already present.
+			var apiLang []string
+			if code := normalizeLanguageCode(v.DefaultAudioLanguage); code != "" {
+				apiLang = []string{code}
 			}
+			info.Language = mergeLanguageCodes(info.Language, apiLang)
+			if len(info.Language) == 0 {
+				log.Printf("WARNING: %s has no language in YAML and YouTube did not return defaultAudioLanguage; leaving empty", info.Name)
+			}
+
+			// Subtitles follow the same union rule against the
+			// captions.list result.
+			info.Subtitles = mergeLanguageCodes(info.Subtitles, normalizeLanguageCodes(v.Subtitles))
 		}
 
 		if info.VideoID != "" {
@@ -174,6 +180,45 @@ func cmdCollectMovieData(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// normalizeLanguageCodes maps normalizeLanguageCode over a slice and
+// drops empties. It does not deduplicate — that is mergeLanguageCodes'
+// job, which keeps the dedupe logic in one place.
+func normalizeLanguageCodes(tags []string) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if c := normalizeLanguageCode(t); c != "" {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// mergeLanguageCodes returns the union of yamlCodes and apiCodes,
+// preserving yamlCodes order first, then appending any apiCodes
+// not already present. Both inputs are normalized via
+// normalizeLanguageCode; empty results are dropped.
+func mergeLanguageCodes(yamlCodes, apiCodes []string) []string {
+	seen := make(map[string]struct{}, len(yamlCodes)+len(apiCodes))
+	var out []string
+	for _, list := range [][]string{yamlCodes, apiCodes} {
+		for _, raw := range list {
+			c := normalizeLanguageCode(raw)
+			if c == "" {
+				continue
+			}
+			if _, dup := seen[c]; dup {
+				continue
+			}
+			seen[c] = struct{}{}
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 // normalizeLanguageCode reduces a BCP-47 tag to its base ISO 639-1

--- a/app/cmd/collectMovieData_test.go
+++ b/app/cmd/collectMovieData_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeLanguageCodes(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml []string
+		api  []string
+		want []string
+	}{
+		{
+			name: "both empty",
+			want: nil,
+		},
+		{
+			name: "yaml empty, api populated",
+			api:  []string{"en"},
+			want: []string{"en"},
+		},
+		{
+			name: "yaml populated, api empty",
+			yaml: []string{"de", "en"},
+			want: []string{"de", "en"},
+		},
+		{
+			name: "overlap is deduped, yaml order preserved",
+			yaml: []string{"en"},
+			api:  []string{"en", "de"},
+			want: []string{"en", "de"},
+		},
+		{
+			name: "BCP-47 tags normalize to ISO 639-1 before union",
+			yaml: []string{"en-US"},
+			api:  []string{"de-DE", "EN"},
+			want: []string{"en", "de"},
+		},
+		{
+			name: "empty/whitespace entries are dropped",
+			yaml: []string{"", " "},
+			api:  []string{"fr"},
+			want: []string{"fr"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeLanguageCodes(tc.yaml, tc.api)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("mergeLanguageCodes(%v, %v) = %v; want %v", tc.yaml, tc.api, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeLanguageCodes(t *testing.T) {
+	got := normalizeLanguageCodes([]string{"en-US", "", "DE", "fr-FR"})
+	want := []string{"en", "de", "fr"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeLanguageCodes = %v; want %v", got, want)
+	}
+	if normalizeLanguageCodes(nil) != nil {
+		t.Fatalf("normalizeLanguageCodes(nil) should be nil")
+	}
+}

--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -135,16 +135,20 @@ func cmdConvertYamlToJson(cmd *cobra.Command, args []string) error {
 // fields already present in target. If the YAML schema gains new
 // curated fields, they must be added here as well.
 //
-// Language and Description are special: both are optional in YAML.
-// If the YAML omits them we keep whatever target already has (which
-// may be a value previously derived from the YouTube API in
+// Language, Subtitles and Description are special: all are optional
+// in YAML. If the YAML omits them we keep whatever target already has
+// (which may be a value previously derived from the YouTube API in
 // collectMovieData), so the YAML acts as an override rather than a
-// forced reset.
+// forced reset. The union with API-supplied codes is performed later
+// in collectMovieData; here we only handle the YAML-vs-cached merge.
 func mergeMovieInformation(source, target *MovieInformation) *MovieInformation {
 	target.Name = source.Name
 	target.Link = source.Link
 	if len(source.Language) > 0 {
 		target.Language = source.Language
+	}
+	if len(source.Subtitles) > 0 {
+		target.Subtitles = source.Subtitles
 	}
 	if len(source.Description) > 0 {
 		target.Description = source.Description

--- a/app/cmd/convertYamlToJson_test.go
+++ b/app/cmd/convertYamlToJson_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import "testing"
 
-// mergeMovieInformation has two override-only fields (Language,
-// Description) whose YAML > API precedence is easy to break by
-// accident on schema changes. These tests pin the contract.
+// mergeMovieInformation has three override-only fields (Language,
+// Subtitles, Description) whose YAML > API precedence is easy to
+// break by accident on schema changes. These tests pin the contract.
 
 func TestMergeMovieInformation_DescriptionPrecedence(t *testing.T) {
 	t.Run("YAML description overrides target", func(t *testing.T) {
@@ -46,6 +46,28 @@ func TestMergeMovieInformation_LanguagePrecedence(t *testing.T) {
 		got := mergeMovieInformation(yaml, json)
 		if len(got.Language) != 1 || got.Language[0] != "en" {
 			t.Fatalf("Language = %v; want [en] (target preserved)", got.Language)
+		}
+	})
+}
+
+func TestMergeMovieInformation_SubtitlesPrecedence(t *testing.T) {
+	t.Run("YAML subtitles override target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l", Subtitles: []string{"de"}}
+		json := &MovieInformation{Name: "stale", Link: "stale", Subtitles: []string{"en", "fr"}}
+
+		got := mergeMovieInformation(yaml, json)
+		if len(got.Subtitles) != 1 || got.Subtitles[0] != "de" {
+			t.Fatalf("Subtitles = %v; want [de]", got.Subtitles)
+		}
+	})
+
+	t.Run("empty YAML subtitles preserves target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l"} // Subtitles empty
+		json := &MovieInformation{Name: "stale", Link: "stale", Subtitles: []string{"en", "de"}}
+
+		got := mergeMovieInformation(yaml, json)
+		if len(got.Subtitles) != 2 || got.Subtitles[0] != "en" || got.Subtitles[1] != "de" {
+			t.Fatalf("Subtitles = %v; want [en de] (target preserved)", got.Subtitles)
 		}
 	})
 }

--- a/app/cmd/types.go
+++ b/app/cmd/types.go
@@ -26,7 +26,11 @@ type MovieInformation struct {
 	// Curated by hand because the YouTube API does not reliably expose
 	// the audio language of a video.
 	Language []string `yaml:"language" json:"language"`
-	Tags     []string `yaml:"tags"     json:"tags"`
+	// Subtitles is a list of ISO 639-1 codes for the subtitle/caption
+	// tracks the video is available with. Curated in YAML and unioned
+	// with the languages reported by the YouTube captions.list API.
+	Subtitles []string `yaml:"subtitles" json:"subtitles"`
+	Tags      []string `yaml:"tags"      json:"tags"`
 
 	// API-enriched fields below this line.
 	Title string `yaml:"-" json:"title"`
@@ -50,6 +54,11 @@ func (m *MovieInformation) TagsAsList() string {
 // LanguagesAsList returns the language codes joined with ", ".
 func (m *MovieInformation) LanguagesAsList() string {
 	return strings.Join(m.Language, ", ")
+}
+
+// SubtitlesAsList returns the subtitle codes joined with ", ".
+func (m *MovieInformation) SubtitlesAsList() string {
+	return strings.Join(m.Subtitles, ", ")
 }
 
 // DurationHumanReadable converts the ISO-8601 duration into an

--- a/app/youtube/videos.go
+++ b/app/youtube/videos.go
@@ -3,6 +3,7 @@ package youtube
 import (
 	"context"
 	"fmt"
+	"log"
 
 	youtubeapi "google.golang.org/api/youtube/v3"
 )
@@ -30,6 +31,10 @@ type Video struct {
 	// optional field on the YouTube upload form, especially missing
 	// on older videos.
 	DefaultAudioLanguage string
+	// Subtitles is the deduplicated list of caption-track languages
+	// reported by captions.list, as raw BCP-47 tags. Normalization to
+	// ISO 639-1 happens in the caller.
+	Subtitles []string
 }
 
 // videosListMaxIDs is the YouTube API hard limit for videos.list IDs
@@ -79,10 +84,52 @@ func (c *Client) GetVideoDetails(ctx context.Context, ids []string) ([]Video, er
 			if item.Statistics != nil {
 				v.ViewCount = int64(item.Statistics.ViewCount)
 			}
+
+			// captions.list has no batch form — one call per video. At
+			// 50 quota units each it is the heaviest part of this
+			// command, but the curated movie list is small enough that
+			// the total quota stays well within the daily budget.
+			subs, err := c.GetCaptionLanguages(ctx, v.ID)
+			if err != nil {
+				log.Printf("WARNING: youtube: captions.list for %s failed: %v; leaving subtitles empty", v.ID, err)
+			} else {
+				v.Subtitles = subs
+			}
+
 			out = append(out, v)
 		}
 	}
 
+	return out, nil
+}
+
+// GetCaptionLanguages returns the deduplicated set of language codes
+// (raw BCP-47 tags) for the caption tracks attached to a video. Empty
+// slice when the video has no captions. Auto-generated tracks are
+// included — they appear in the API response just like uploaded
+// tracks.
+func (c *Client) GetCaptionLanguages(ctx context.Context, videoID string) ([]string, error) {
+	resp, err := c.svc.Captions.List([]string{"snippet"}, videoID).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("youtube: captions.list: %w", err)
+	}
+
+	seen := make(map[string]struct{}, len(resp.Items))
+	var out []string
+	for _, item := range resp.Items {
+		if item == nil || item.Snippet == nil {
+			continue
+		}
+		lang := item.Snippet.Language
+		if lang == "" {
+			continue
+		}
+		if _, dup := seen[lang]; dup {
+			continue
+		}
+		seen[lang] = struct{}{}
+		out = append(out, lang)
+	}
 	return out, nil
 }
 


### PR DESCRIPTION
## Summary
- Adds a `Subtitles []string` schema field alongside `Language`, both editable in YAML and persisted to JSON.
- Wires `captions.list` into the enrichment pass so subtitle languages are auto-discovered for every YouTube video.
- Generalizes the YAML-vs-API merge rule for both fields: YAML order is preserved, API-supplied codes are appended only if missing (was: all-or-nothing replace).

## Why
The schema previously captured only audio language. Subtitles signal accessibility independently of the spoken track and were not represented. The new union semantics also let a curator list one canonical code in YAML and trust the API to fill in the rest without their edits being overwritten.

## Notes
- `captions.list` has no batch form — one call per video at 50 quota units. Curated list is small enough that daily quota is unaffected; documented inline.
- Per-video captions errors log a warning and leave `Subtitles` empty, matching existing fail-soft enrichment behavior.
- New `mergeLanguageCodes` / `normalizeLanguageCodes` helpers centralize normalization + dedupe.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` green (new table tests for `mergeLanguageCodes`, `normalizeLanguageCodes`, plus subtitles precedence cases in `mergeMovieInformation`)
- [ ] Run `collectMovieData` against the live YouTube API with a real key and verify a known multi-caption video ends up with multiple `subtitles` codes
- [ ] Set `subtitles: [en]` in a YAML for a video known to have additional caption tracks, re-run, confirm output is the union (e.g. `[en, de]`)