### PR TITLE
Add YouTube ratings and group views by source in generated JSON

### DIFF
--- a/app/cmd/collectMovieData.go
+++ b/app/cmd/collectMovieData.go
@@ -136,7 +136,10 @@ func cmdCollectMovieData(cmd *cobra.Command, args []string) error {
 			info.Duration = v.Duration
 			info.PublishedAt = v.PublishedAt
 			info.Channel = v.Channel
-			info.ViewCount = v.ViewCount
+
+			views := v.ViewCount
+			info.Views.YouTube = &views
+			info.Ratings.YouTube = &YouTubeRating{LikeCount: v.LikeCount}
 
 			// Description is YAML-overridable: only use the API value
 			// when the YAML left it empty. Same precedence as Language.

--- a/app/cmd/types.go
+++ b/app/cmd/types.go
@@ -42,8 +42,36 @@ type MovieInformation struct {
 	Duration    string          `yaml:"-"                     json:"duration"` // ISO-8601, e.g. PT43M22S
 	PublishedAt string          `yaml:"-" json:"publishedAt"`
 	Channel     youtube.Channel `yaml:"-" json:"channel"`
-	ViewCount   int64           `yaml:"-" json:"viewCount"`
-	Image       string          `yaml:"-" json:"image"`
+	// Ratings groups rating signals by source. Today only YouTube is
+	// populated (likeCount); a future second source — e.g. an external
+	// review aggregator — would slot in as another key.
+	Ratings Ratings `yaml:"-" json:"ratings,omitzero"`
+	// Views groups view counts by source. Today only YouTube is
+	// populated. Per-source attribution makes the provenance explicit
+	// in the JSON itself.
+	Views Views  `yaml:"-" json:"views,omitzero"`
+	Image string `yaml:"-" json:"image"`
+}
+
+// YouTubeRating holds rating-like signals YouTube exposes via
+// videos.list.statistics. Aggregate rating numbers are no longer
+// public (dislikes were removed in 2021), so likeCount is the only
+// signal worth recording.
+type YouTubeRating struct {
+	LikeCount int64 `json:"likeCount"`
+}
+
+// Ratings is the per-source rating container. Keys are omitted when
+// the corresponding source has not been queried, so presence of a key
+// doubles as a source-attribution marker.
+type Ratings struct {
+	YouTube *YouTubeRating `json:"youtube,omitempty"`
+}
+
+// Views is the per-source view-count container. Same omitempty
+// convention as Ratings.
+type Views struct {
+	YouTube *int64 `json:"youtube,omitempty"`
 }
 
 // TagsAsList returns the tags joined with ", " for README rendering.

--- a/app/youtube/videos.go
+++ b/app/youtube/videos.go
@@ -25,6 +25,7 @@ type Video struct {
 	PublishedAt string // RFC3339
 	Channel     Channel
 	ViewCount   int64
+	LikeCount   int64
 	Thumbnail   string // highest-resolution thumbnail URL the API offers
 	// DefaultAudioLanguage is the uploader-declared audio language as
 	// a BCP-47 tag (e.g. "en", "en-US"). Often empty: it is an
@@ -83,6 +84,7 @@ func (c *Client) GetVideoDetails(ctx context.Context, ids []string) ([]Video, er
 			}
 			if item.Statistics != nil {
 				v.ViewCount = int64(item.Statistics.ViewCount)
+				v.LikeCount = int64(item.Statistics.LikeCount)
 			}
 
 			// captions.list has no batch form — one call per video. At

--- a/generated/angular-the-documentary.json
+++ b/generated/angular-the-documentary.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Frontend",
   "JavaScript",
@@ -21,6 +24,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 120742,
+ "ratings": {
+  "youtube": {
+   "likeCount": 3546
+  }
+ },
+ "views": {
+  "youtube": 120750
+ },
  "image": "images/angular-the-documentary.jpg"
 }

--- a/generated/clojure-the-documentary.json
+++ b/generated/clojure-the-documentary.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Programming Languages",
   "Functional Programming",
@@ -20,6 +23,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 185460,
+ "ratings": {
+  "youtube": {
+   "likeCount": 3584
+  }
+ },
+ "views": {
+  "youtube": 185484
+ },
  "image": "images/clojure-the-documentary.jpg"
 }

--- a/generated/code-debugging-the-gender-gap.json
+++ b/generated/code-debugging-the-gender-gap.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Girls",
   "STEM",
@@ -19,6 +22,13 @@
   "id": "UCX1nchEcBshItKBeJvH-YMw",
   "title": "FREE MOVIES"
  },
- "viewCount": 5346,
+ "ratings": {
+  "youtube": {
+   "likeCount": 50
+  }
+ },
+ "views": {
+  "youtube": 5346
+ },
  "image": "images/code-debugging-the-gender-gap.jpg"
 }

--- a/generated/ebpf-unlocking-the-kernel.json
+++ b/generated/ebpf-unlocking-the-kernel.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Linux",
   "Kernel",
@@ -20,6 +23,13 @@
   "id": "UCro9rA8-YX-26UVNY8ewAKQ",
   "title": " Speakeasy Productions"
  },
- "viewCount": 165129,
+ "ratings": {
+  "youtube": {
+   "likeCount": 4777
+  }
+ },
+ "views": {
+  "youtube": 165131
+ },
  "image": "images/ebpf-unlocking-the-kernel.jpg"
 }

--- a/generated/elixir-the-documentary.json
+++ b/generated/elixir-the-documentary.json
@@ -6,6 +6,10 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en",
+  "pt"
+ ],
  "tags": [
   "Programming Languages",
   "Functional Programming",
@@ -20,6 +24,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 261669,
+ "ratings": {
+  "youtube": {
+   "likeCount": 8057
+  }
+ },
+ "views": {
+  "youtube": 261673
+ },
  "image": "images/elixir-the-documentary.jpg"
 }

--- a/generated/ember-js-the-documentary.json
+++ b/generated/ember-js-the-documentary.json
@@ -6,6 +6,11 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "pt",
+  "vi",
+  "en"
+ ],
  "tags": [
   "Frontend",
   "JavaScript",
@@ -20,6 +25,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 132565,
+ "ratings": {
+  "youtube": {
+   "likeCount": 2452
+  }
+ },
+ "views": {
+  "youtube": 132566
+ },
  "image": "images/ember-js-the-documentary.jpg"
 }

--- a/generated/graphql-the-documentary.json
+++ b/generated/graphql-the-documentary.json
@@ -6,6 +6,14 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "es",
+  "zh",
+  "pt",
+  "vi",
+  "en",
+  "ja"
+ ],
  "tags": [
   "API",
   "Open Source",
@@ -19,6 +27,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 599157,
+ "ratings": {
+  "youtube": {
+   "likeCount": 15214
+  }
+ },
+ "views": {
+  "youtube": 599159
+ },
  "image": "images/graphql-the-documentary.jpg"
 }

--- a/generated/half-life-25th-anniversary-documentary.json
+++ b/generated/half-life-25th-anniversary-documentary.json
@@ -6,6 +6,34 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en",
+  "sv",
+  "hu",
+  "de",
+  "es",
+  "pl",
+  "ru",
+  "da",
+  "tr",
+  "ja",
+  "pt",
+  "nl",
+  "id",
+  "uk",
+  "bg",
+  "ko",
+  "fr",
+  "fi",
+  "vi",
+  "zh",
+  "ro",
+  "it",
+  "cs",
+  "th",
+  "el",
+  "no"
+ ],
  "tags": [
   "Game Development",
   "Valve",
@@ -19,6 +47,13 @@
   "id": "UCg0FSqPeiGD_lIiPaaAehQg",
   "title": "Valve"
  },
- "viewCount": 7853830,
+ "ratings": {
+  "youtube": {
+   "likeCount": 280097
+  }
+ },
+ "views": {
+  "youtube": 7853868
+ },
  "image": "images/half-life-25th-anniversary-documentary.jpg"
 }

--- a/generated/inside-envoy.json
+++ b/generated/inside-envoy.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Networking",
   "Service Mesh",
@@ -20,6 +23,13 @@
   "id": "UCro9rA8-YX-26UVNY8ewAKQ",
   "title": " Speakeasy Productions"
  },
- "viewCount": 116975,
+ "ratings": {
+  "youtube": {
+   "likeCount": 572
+  }
+ },
+ "views": {
+  "youtube": 116975
+ },
  "image": "images/inside-envoy-the-proxy-for-the-future.jpg"
 }

--- a/generated/intellij-idea-the-documentary.json
+++ b/generated/intellij-idea-the-documentary.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Developer Tools",
   "IDE",
@@ -20,6 +23,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 42369,
+ "ratings": {
+  "youtube": {
+   "likeCount": 1510
+  }
+ },
+ "views": {
+  "youtube": 42369
+ },
  "image": "images/intellij-idea-the-documentary.jpg"
 }

--- a/generated/internet-relay-chat-irc.json
+++ b/generated/internet-relay-chat-irc.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Networking",
   "Chat",
@@ -20,6 +23,13 @@
   "id": "UCgbw0F-frjDxvQjzruGRJwg",
   "title": "The Serial Port"
  },
- "viewCount": 256338,
+ "ratings": {
+  "youtube": {
+   "likeCount": 15202
+  }
+ },
+ "views": {
+  "youtube": 256337
+ },
  "image": "images/internet-relay-chat-irc.jpg"
 }

--- a/generated/kubernetes-the-documentary-part-1.json
+++ b/generated/kubernetes-the-documentary-part-1.json
@@ -6,6 +6,14 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "ko",
+  "es",
+  "zh",
+  "en",
+  "de",
+  "ru"
+ ],
  "tags": [
   "Cloud Native",
   "Orchestration",
@@ -20,6 +28,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 514031,
+ "ratings": {
+  "youtube": {
+   "likeCount": 12674
+  }
+ },
+ "views": {
+  "youtube": 514035
+ },
  "image": "images/kubernetes-the-documentary-part-1.jpg"
 }

--- a/generated/kubernetes-the-documentary-part-2.json
+++ b/generated/kubernetes-the-documentary-part-2.json
@@ -6,6 +6,13 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "zh",
+  "en",
+  "de",
+  "es",
+  "ru"
+ ],
  "tags": [
   "Cloud Native",
   "Orchestration",
@@ -20,6 +27,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 225256,
+ "ratings": {
+  "youtube": {
+   "likeCount": 5947
+  }
+ },
+ "views": {
+  "youtube": 225256
+ },
  "image": "images/kubernetes-the-documentary-part-2.jpg"
 }

--- a/generated/laravel-origins-a-php-documentary.json
+++ b/generated/laravel-origins-a-php-documentary.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Web Frameworks",
   "PHP",
@@ -20,6 +23,13 @@
   "id": "UCDstQZHA9T8-ZP046R0KEXA",
   "title": "OfferZen Origins"
  },
- "viewCount": 172223,
+ "ratings": {
+  "youtube": {
+   "likeCount": 6778
+  }
+ },
+ "views": {
+  "youtube": 172223
+ },
  "image": "images/laravel-origins-a-php-documentary.jpg"
 }

--- a/generated/node-js-the-documentary.json
+++ b/generated/node-js-the-documentary.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "JavaScript",
   "Backend",
@@ -20,6 +23,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 835044,
+ "ratings": {
+  "youtube": {
+   "likeCount": 23867
+  }
+ },
+ "views": {
+  "youtube": 835053
+ },
  "image": "images/node-js-the-documentary.jpg"
 }

--- a/generated/prometheus-the-documentary.json
+++ b/generated/prometheus-the-documentary.json
@@ -6,6 +6,11 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "ru",
+  "en",
+  "zh"
+ ],
  "tags": [
   "Observability",
   "Monitoring",
@@ -21,6 +26,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 143720,
+ "ratings": {
+  "youtube": {
+   "likeCount": 3547
+  }
+ },
+ "views": {
+  "youtube": 143723
+ },
  "image": "images/prometheus-the-documentary.jpg"
 }

--- a/generated/python-the-documentary.json
+++ b/generated/python-the-documentary.json
@@ -6,6 +6,10 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en",
+  "ko"
+ ],
  "tags": [
   "Programming Languages",
   "Open Source",
@@ -19,6 +23,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 1078703,
+ "ratings": {
+  "youtube": {
+   "likeCount": 33455
+  }
+ },
+ "views": {
+  "youtube": 1078731
+ },
  "image": "images/python-the-documentary.jpg"
 }

--- a/generated/react-js-the-documentary.json
+++ b/generated/react-js-the-documentary.json
@@ -6,6 +6,11 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en",
+  "es",
+  "pt"
+ ],
  "tags": [
   "Frontend",
   "JavaScript",
@@ -21,6 +26,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 1641133,
+ "ratings": {
+  "youtube": {
+   "likeCount": 40560
+  }
+ },
+ "views": {
+  "youtube": 1641145
+ },
  "image": "images/react-js-the-documentary.jpg"
 }

--- a/generated/revolution-os.json
+++ b/generated/revolution-os.json
@@ -6,6 +6,28 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "sl",
+  "bg",
+  "es",
+  "ru",
+  "cs",
+  "el",
+  "bn",
+  "zh",
+  "ar",
+  "de",
+  "mk",
+  "pt",
+  "fr",
+  "tr",
+  "sr",
+  "ro",
+  "hr",
+  "en",
+  "pl",
+  "hu"
+ ],
  "tags": [
   "GNU/Linux",
   "Open Source",
@@ -19,6 +41,13 @@
   "id": "UCqHGotzs8NZABgorJjWNppg",
   "title": "Adam N."
  },
- "viewCount": 86729,
+ "ratings": {
+  "youtube": {
+   "likeCount": 2191
+  }
+ },
+ "views": {
+  "youtube": 86731
+ },
  "image": "images/revolution-os.jpg"
 }

--- a/generated/ruby-on-rails-the-documentary.json
+++ b/generated/ruby-on-rails-the-documentary.json
@@ -6,6 +6,11 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "es",
+  "de",
+  "en"
+ ],
  "tags": [
   "Web Frameworks",
   "Ruby",
@@ -20,6 +25,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 319671,
+ "ratings": {
+  "youtube": {
+   "likeCount": 9836
+  }
+ },
+ "views": {
+  "youtube": 319671
+ },
  "image": "images/ruby-on-rails-the-documentary.jpg"
 }

--- a/generated/svelte-origins-a-javascript-documentary.json
+++ b/generated/svelte-origins-a-javascript-documentary.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Frontend",
   "JavaScript",
@@ -20,6 +23,13 @@
   "id": "UCDstQZHA9T8-ZP046R0KEXA",
   "title": "OfferZen Origins"
  },
- "viewCount": 211147,
+ "ratings": {
+  "youtube": {
+   "likeCount": 6992
+  }
+ },
+ "views": {
+  "youtube": 211149
+ },
  "image": "images/svelte-origins-a-javascript-documentary.jpg"
 }

--- a/generated/the-internets-own-boy-aaron-swartz.json
+++ b/generated/the-internets-own-boy-aaron-swartz.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Hacktivism",
   "Open Internet",
@@ -20,6 +23,13 @@
   "id": "UCYCEK7i8Uq-XtFtWolofxFg",
   "title": "moviemaniacsDE"
  },
- "viewCount": 2445128,
+ "ratings": {
+  "youtube": {
+   "likeCount": 36686
+  }
+ },
+ "views": {
+  "youtube": 2445135
+ },
  "image": "images/the-internets-own-boy-the-story-of-aaron-swartz.jpg"
 }

--- a/generated/typescript-origins-the-documentary.json
+++ b/generated/typescript-origins-the-documentary.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Programming Languages",
   "JavaScript",
@@ -20,6 +23,13 @@
   "id": "UCDstQZHA9T8-ZP046R0KEXA",
   "title": "OfferZen Origins"
  },
- "viewCount": 348014,
+ "ratings": {
+  "youtube": {
+   "likeCount": 9556
+  }
+ },
+ "views": {
+  "youtube": 348014
+ },
  "image": "images/typescript-origins-the-documentary.jpg"
 }

--- a/generated/vite-the-documentary.json
+++ b/generated/vite-the-documentary.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Frontend",
   "Build Tools",
@@ -20,6 +23,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 151845,
+ "ratings": {
+  "youtube": {
+   "likeCount": 5905
+  }
+ },
+ "views": {
+  "youtube": 151851
+ },
  "image": "images/vite-the-documentary.jpg"
 }

--- a/generated/vue-js-the-documentary.json
+++ b/generated/vue-js-the-documentary.json
@@ -6,6 +6,16 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en",
+  "pt",
+  "zh",
+  "vi",
+  "tr",
+  "fr",
+  "ru",
+  "es"
+ ],
  "tags": [
   "Frontend",
   "JavaScript",
@@ -20,6 +30,13 @@
   "id": "UCsUalyRg43M8D60mtHe6YcA",
   "title": "CultRepo "
  },
- "viewCount": 1638042,
+ "ratings": {
+  "youtube": {
+   "likeCount": 52870
+  }
+ },
+ "views": {
+  "youtube": 1638042
+ },
  "image": "images/vue-js-the-documentary.jpg"
 }

--- a/generated/we-are-legion-the-story-of-the-hacktivists.json
+++ b/generated/we-are-legion-the-story-of-the-hacktivists.json
@@ -6,6 +6,9 @@
  "language": [
   "en"
  ],
+ "subtitles": [
+  "en"
+ ],
  "tags": [
   "Anonymous",
   "Hacktivism",
@@ -20,6 +23,13 @@
   "id": "UCYAEYAvA9A-f_JzDh8WJ5Zg",
   "title": "World Documentary"
  },
- "viewCount": 65069,
+ "ratings": {
+  "youtube": {
+   "likeCount": 1048
+  }
+ },
+ "views": {
+  "youtube": 65070
+ },
  "image": "images/we-are-legion-the-story-of-the-hacktivists.jpg"
 }


### PR DESCRIPTION
## Summary
- Pull a `likeCount` rating from the YouTube Data API for each entry and store it under `ratings.youtube.likeCount` in the generated JSON.
- Restructure views into `views.youtube` so the provenance of every view count is explicit in the JSON shape; replaces the old top-level `viewCount`.
- Per-source nesting leaves room for a future second rating source to slot in (e.g. `ratings.imdb`) without further restructuring.

## Context
YouTube no longer publishes an aggregate rating (dislikes were removed in 2021), so `likeCount` from `videos.list.statistics` is the only useful signal — it lives inside the `statistics` part we already request, no extra quota cost. Empty per-source containers are dropped from the JSON via ` ,omitzero ` so non-YouTube entries never carry `\"ratings\": {}` / `\"views\": {}` placeholders.

The only consumer of the generated JSON is the in-repo README converter, which never read `viewCount`, so the old field is removed rather than kept in parallel.

### Sample output (`generated/python-the-documentary.json`)
```json
\"ratings\": {
  \"youtube\": {
    \"likeCount\": 33455
  }
},
\"views\": {
  \"youtube\": 1078731
}
```

## Test plan
- [x] `cd app && go build ./...`
- [x] `cd app && go vet ./...`
- [x] `cd app && go test ./...`
- [x] `go run . collectMovieData --json-directory ../generated` — all 26 generated JSON files regenerated cleanly
- [x] Spot-checked `generated/python-the-documentary.json` for the new shape
- [x] Confirmed no `\"viewCount\"` remains anywhere under `generated/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)