### PR TITLE
Add platform field with autodetection and source-aware Watch link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,9 +72,10 @@ non-commercial dataset.
 | `description` | string         | no       | YAML > API      | Free text. If omitted, the tooling uses the video's YouTube description. Set it manually when the YouTube description is empty, full of unrelated boilerplate, or otherwise unhelpful for skim-reading the README. |
 | `tags`        | list[string]   | yes      | YAML            | Subject-matter tags. Be coarse — better to have 3–5 broad tags than 15 narrow ones. |
 | `imdbID`      | string         | no       | YAML            | IMDb tconst (e.g. `tt3268458`). Set this only when the entry is also catalogued on IMDb so the tooling can pull the IMDb rating from the public dataset. Most YouTube documentaries are not on IMDb — leave this unset for those. |
+| `platform`    | string         | no       | YAML > tooling  | Slug of the source the link lives on (`youtube` today). Auto-detected from `link` when omitted; set explicitly only if you need to override the detector or your link is from a source the tooling does not yet recognise. The tooling logs a warning when an explicit platform disagrees with what the link looks like. |
 
 The remaining JSON fields (`title`, `duration`, `publishedAt`,
-`channel`, `ratings`, `views`, `image`, `slug`, `videoID`) are
-produced by the tooling. **Do not edit `README.md` directly** —
+`channel`, `ratings`, `views`, `image`, `slug`, `videoID`,
+`platform` when not set in YAML) are produced by the tooling. **Do not edit `README.md` directly** —
 it is overwritten on every CI run. To change rendering, update
 `assets/README.template`.

--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/EngineeringKiosk/awesome-software-engineering-movies/io"
+	"github.com/EngineeringKiosk/awesome-software-engineering-movies/platform"
 	"github.com/EngineeringKiosk/awesome-software-engineering-movies/youtube"
 )
 
@@ -117,6 +118,7 @@ func cmdConvertYamlToJson(cmd *cobra.Command, args []string) error {
 		} else {
 			log.Printf("WARNING: could not parse YouTube video ID from %q in %s", movieInfo.Link, absYamlFilePath)
 		}
+		resolvePlatform(movieInfo, absYamlFilePath)
 
 		log.Printf("Write %s to disk ...", absJsonFilePath)
 		err = io.WriteJSONFile(absJsonFilePath, movieInfo)
@@ -156,6 +158,38 @@ func mergeMovieInformation(source, target *MovieInformation) *MovieInformation {
 	if len(source.IMDbID) > 0 {
 		target.IMDbID = source.IMDbID
 	}
+	if len(source.Platform) > 0 {
+		target.Platform = source.Platform
+	}
 	target.Tags = source.Tags
 	return target
+}
+
+// resolvePlatform fills in info.Platform from the link when YAML did
+// not set it, and warns on the cases the maintainer should know
+// about: YAML disagrees with the link, YAML names a platform whose
+// link the tooling cannot recognise, or neither YAML nor the link
+// yields a platform.
+//
+// The YAML value always wins — this function never overwrites a
+// non-empty Platform.
+//
+// fileLabel is the human-friendly file path used only in the warning
+// text; passing it in keeps the function pure-ish (no globals) and
+// trivially testable.
+func resolvePlatform(info *MovieInformation, fileLabel string) {
+	detected, detectedOK := platform.Detect(info.Link)
+	switch {
+	case info.Platform == "" && detectedOK:
+		info.Platform = detected
+	case info.Platform == "" && !detectedOK:
+		log.Printf("WARNING: %s has no platform in YAML and link %q matches no known platform; leaving empty",
+			fileLabel, info.Link)
+	case info.Platform != "" && detectedOK && info.Platform != detected:
+		log.Printf("WARNING: %s YAML platform %q disagrees with link-detected platform %q; keeping YAML value",
+			fileLabel, info.Platform, detected)
+	case info.Platform != "" && !detectedOK:
+		log.Printf("WARNING: %s YAML platform %q set but link %q matches no known platform; keeping YAML value",
+			fileLabel, info.Platform, info.Link)
+	}
 }

--- a/app/cmd/convertYamlToJson_test.go
+++ b/app/cmd/convertYamlToJson_test.go
@@ -1,6 +1,11 @@
 package cmd
 
-import "testing"
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
 
 // mergeMovieInformation has three override-only fields (Language,
 // Subtitles, Description) whose YAML > API precedence is easy to
@@ -68,6 +73,93 @@ func TestMergeMovieInformation_SubtitlesPrecedence(t *testing.T) {
 		got := mergeMovieInformation(yaml, json)
 		if len(got.Subtitles) != 2 || got.Subtitles[0] != "en" || got.Subtitles[1] != "de" {
 			t.Fatalf("Subtitles = %v; want [en de] (target preserved)", got.Subtitles)
+		}
+	})
+}
+
+func TestResolvePlatform(t *testing.T) {
+	cases := []struct {
+		name        string
+		yamlValue   string
+		link        string
+		wantValue   string
+		wantWarnSub string // empty = expect no warning
+	}{
+		{
+			name:      "autodetect from YouTube link when YAML omits platform",
+			link:      "https://www.youtube.com/watch?v=abc123",
+			wantValue: "youtube",
+		},
+		{
+			name:      "explicit YAML matches detector → no warning",
+			yamlValue: "youtube",
+			link:      "https://youtu.be/abc123",
+			wantValue: "youtube",
+		},
+		{
+			name:        "YAML disagrees with link → warn, keep YAML",
+			yamlValue:   "netflix",
+			link:        "https://www.youtube.com/watch?v=abc123",
+			wantValue:   "netflix",
+			wantWarnSub: "disagrees with link-detected platform",
+		},
+		{
+			name:        "YAML set, link unrecognised → warn, keep YAML",
+			yamlValue:   "netflix",
+			link:        "https://example.com/foo",
+			wantValue:   "netflix",
+			wantWarnSub: "matches no known platform; keeping YAML value",
+		},
+		{
+			name:        "neither YAML nor detector → warn, leave empty",
+			link:        "https://example.com/foo",
+			wantValue:   "",
+			wantWarnSub: "leaving empty",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := &MovieInformation{Link: tc.link, Platform: tc.yamlValue}
+
+			var buf bytes.Buffer
+			prev := log.Writer()
+			log.SetOutput(&buf)
+			defer log.SetOutput(prev)
+
+			resolvePlatform(info, "test.yml")
+
+			if info.Platform != tc.wantValue {
+				t.Errorf("Platform = %q; want %q", info.Platform, tc.wantValue)
+			}
+			out := buf.String()
+			switch {
+			case tc.wantWarnSub == "" && strings.Contains(out, "WARNING"):
+				t.Errorf("expected no warning, got: %s", out)
+			case tc.wantWarnSub != "" && !strings.Contains(out, tc.wantWarnSub):
+				t.Errorf("expected warning containing %q, got: %s", tc.wantWarnSub, out)
+			}
+		})
+	}
+}
+
+func TestMergeMovieInformation_PlatformPrecedence(t *testing.T) {
+	t.Run("YAML platform overrides target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l", Platform: "netflix"}
+		json := &MovieInformation{Name: "stale", Link: "stale", Platform: "youtube"}
+
+		got := mergeMovieInformation(yaml, json)
+		if got.Platform != "netflix" {
+			t.Fatalf("Platform = %q; want %q", got.Platform, "netflix")
+		}
+	})
+
+	t.Run("empty YAML platform preserves target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l"}
+		json := &MovieInformation{Name: "stale", Link: "stale", Platform: "youtube"}
+
+		got := mergeMovieInformation(yaml, json)
+		if got.Platform != "youtube" {
+			t.Fatalf("Platform = %q; want %q (target preserved)", got.Platform, "youtube")
 		}
 	})
 }

--- a/app/cmd/types.go
+++ b/app/cmd/types.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/EngineeringKiosk/awesome-software-engineering-movies/platform"
 	"github.com/EngineeringKiosk/awesome-software-engineering-movies/youtube"
 )
 
@@ -22,6 +23,12 @@ type MovieInformation struct {
 	Link string `yaml:"link" json:"link"`
 	// VideoID is parsed from Link by convertYamlToJson.
 	VideoID string `yaml:"-" json:"videoID"`
+	// Platform identifies which source the link lives on (e.g.
+	// "youtube"). Optional in YAML — convertYamlToJson auto-fills it
+	// from the link via the platform package when omitted. The YAML
+	// value, when set, always wins; convertYamlToJson logs a warning
+	// when YAML and link disagree.
+	Platform string `yaml:"platform,omitempty" json:"platform"`
 
 	// Language is a list of ISO 639-1 codes (e.g. ["en"], ["en", "de"]).
 	// Curated by hand because the YouTube API does not reliably expose
@@ -111,6 +118,13 @@ func (m *MovieInformation) LanguagesAsList() string {
 // SubtitlesAsList returns the subtitle codes joined with ", ".
 func (m *MovieInformation) SubtitlesAsList() string {
 	return strings.Join(m.Subtitles, ", ")
+}
+
+// PlatformDisplay returns the human-readable platform name for the
+// README, e.g. "YouTube" for the slug "youtube". Empty / unknown
+// slugs degrade gracefully via platform.Display.
+func (m *MovieInformation) PlatformDisplay() string {
+	return platform.Display(m.Platform)
 }
 
 // HasYouTubeLikes reports whether the YouTube rating block is

--- a/app/cmd/types_test.go
+++ b/app/cmd/types_test.go
@@ -42,6 +42,20 @@ func TestDurationHumanReadable(t *testing.T) {
 	}
 }
 
+func TestPlatformDisplay(t *testing.T) {
+	cases := map[string]string{
+		"youtube":  "YouTube",
+		"":         "",
+		"unknown":  "unknown", // delegated to platform.Display, returned verbatim
+	}
+	for slug, want := range cases {
+		m := &MovieInformation{Platform: slug}
+		if got := m.PlatformDisplay(); got != want {
+			t.Errorf("PlatformDisplay(%q) = %q; want %q", slug, got, want)
+		}
+	}
+}
+
 func TestTagsAsList(t *testing.T) {
 	m := &MovieInformation{Tags: []string{"Networking", "Service Mesh"}}
 	if got, want := m.TagsAsList(), "Networking, Service Mesh"; got != want {

--- a/app/cmd/types_test.go
+++ b/app/cmd/types_test.go
@@ -44,9 +44,9 @@ func TestDurationHumanReadable(t *testing.T) {
 
 func TestPlatformDisplay(t *testing.T) {
 	cases := map[string]string{
-		"youtube":  "YouTube",
-		"":         "",
-		"unknown":  "unknown", // delegated to platform.Display, returned verbatim
+		"youtube": "YouTube",
+		"":        "",
+		"unknown": "unknown", // delegated to platform.Display, returned verbatim
 	}
 	for slug, want := range cases {
 		m := &MovieInformation{Platform: slug}

--- a/app/platform/platform.go
+++ b/app/platform/platform.go
@@ -1,0 +1,50 @@
+// Package platform identifies which streaming source a movie link
+// belongs to. It is the single home for the slugs that land in the
+// generated JSON and for the human-readable names rendered into the
+// README. Adding a new source — Netflix, Amazon Prime, Vimeo — means
+// touching this one package and nothing else.
+package platform
+
+import (
+	"github.com/EngineeringKiosk/awesome-software-engineering-movies/youtube"
+)
+
+// Slug constants. The string values land in the generated JSON, so
+// changing them is a breaking change for downstream consumers.
+const (
+	YouTube = "youtube"
+)
+
+// displayNames maps slugs to the human-readable names rendered into
+// the README. Slugs missing from this map are returned by Display
+// unchanged so the rendered output degrades gracefully when a future
+// platform is referenced before its display name is wired up.
+var displayNames = map[string]string{
+	YouTube: "YouTube",
+}
+
+// Detect inspects a link and returns the platform slug it belongs to,
+// or ok=false when the link does not match any known platform.
+//
+// Today only YouTube is recognised; future sources slot in as
+// additional cases below. The YouTube branch defers to
+// youtube.ParseVideoID, which already understands every URL shape
+// the project accepts (`youtu.be`, `youtube.com/watch?v=`, `/embed/`,
+// `/shorts/`).
+func Detect(link string) (string, bool) {
+	if _, ok := youtube.ParseVideoID(link); ok {
+		return YouTube, true
+	}
+	return "", false
+}
+
+// Display returns the human-readable platform name for a slug
+// (e.g. "youtube" → "YouTube"). Empty input returns empty output.
+// Unknown slugs are returned verbatim — better to render a slightly
+// unpolished label than to swallow data the template asked for.
+func Display(slug string) string {
+	if name, ok := displayNames[slug]; ok {
+		return name
+	}
+	return slug
+}

--- a/app/platform/platform_test.go
+++ b/app/platform/platform_test.go
@@ -1,0 +1,43 @@
+package platform
+
+import "testing"
+
+func TestDetect(t *testing.T) {
+	cases := []struct {
+		name string
+		link string
+		slug string
+		ok   bool
+	}{
+		{"youtube watch", "https://www.youtube.com/watch?v=abc123", YouTube, true},
+		{"youtube short host", "https://youtu.be/abc123", YouTube, true},
+		{"youtube embed", "https://www.youtube.com/embed/abc123", YouTube, true},
+		{"youtube shorts", "https://www.youtube.com/shorts/abc123", YouTube, true},
+		{"m.youtube", "https://m.youtube.com/watch?v=abc123", YouTube, true},
+		{"unknown host", "https://www.netflix.com/title/12345", "", false},
+		{"empty link", "", "", false},
+		{"garbage", "not a url", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotSlug, gotOK := Detect(tc.link)
+			if gotSlug != tc.slug || gotOK != tc.ok {
+				t.Fatalf("Detect(%q) = (%q, %v); want (%q, %v)", tc.link, gotSlug, gotOK, tc.slug, tc.ok)
+			}
+		})
+	}
+}
+
+func TestDisplay(t *testing.T) {
+	cases := map[string]string{
+		YouTube:        "YouTube",
+		"":             "",
+		"netflix":      "netflix",      // unknown slug → returned verbatim
+		"amazon_prime": "amazon_prime", // ditto
+	}
+	for in, want := range cases {
+		if got := Display(in); got != want {
+			t.Errorf("Display(%q) = %q; want %q", in, got, want)
+		}
+	}
+}

--- a/assets/README.template
+++ b/assets/README.template
@@ -29,7 +29,7 @@ A curated list of movies, documentaries and other related material to watch rela
 {{ end -}}
 {{ if $movie.HasYouTubeLikes }}* YouTube likes: {{ $movie.YouTubeLikeCountFormatted }}
 {{ end -}}
-* [Watch on YouTube]({{ $movie.Link }})
+* [Watch on {{ $movie.PlatformDisplay }}]({{ $movie.Link }})
 
 ----
 {{ end }}

--- a/generated/angular-the-documentary.json
+++ b/generated/angular-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "angular-the-documentary",
  "link": "https://www.youtube.com/watch?v=cRC9DlH45lA",
  "videoID": "cRC9DlH45lA",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/clojure-the-documentary.json
+++ b/generated/clojure-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "clojure-the-documentary",
  "link": "https://www.youtube.com/watch?v=Y24vK_QDLFg",
  "videoID": "Y24vK_QDLFg",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/code-debugging-the-gender-gap.json
+++ b/generated/code-debugging-the-gender-gap.json
@@ -3,6 +3,7 @@
  "slug": "code-debugging-the-gender-gap",
  "link": "https://www.youtube.com/watch?v=rQKRw6tWsb8",
  "videoID": "rQKRw6tWsb8",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/ebpf-unlocking-the-kernel.json
+++ b/generated/ebpf-unlocking-the-kernel.json
@@ -3,6 +3,7 @@
  "slug": "ebpf-unlocking-the-kernel",
  "link": "https://www.youtube.com/watch?v=Wb_vD3XZYOA",
  "videoID": "Wb_vD3XZYOA",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/elixir-the-documentary.json
+++ b/generated/elixir-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "elixir-the-documentary",
  "link": "https://www.youtube.com/watch?v=lxYFOM3UJzo",
  "videoID": "lxYFOM3UJzo",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/ember-js-the-documentary.json
+++ b/generated/ember-js-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "ember-js-the-documentary",
  "link": "https://www.youtube.com/watch?v=Cvz-9ccflKQ",
  "videoID": "Cvz-9ccflKQ",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/graphql-the-documentary.json
+++ b/generated/graphql-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "graphql-the-documentary",
  "link": "https://www.youtube.com/watch?v=783ccP__No8",
  "videoID": "783ccP__No8",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/half-life-25th-anniversary-documentary.json
+++ b/generated/half-life-25th-anniversary-documentary.json
@@ -3,6 +3,7 @@
  "slug": "half-life-25th-anniversary-documentary",
  "link": "https://www.youtube.com/watch?v=TbZ3HzvFEto",
  "videoID": "TbZ3HzvFEto",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/inside-envoy.json
+++ b/generated/inside-envoy.json
@@ -3,6 +3,7 @@
  "slug": "inside-envoy-the-proxy-for-the-future",
  "link": "https://www.youtube.com/watch?v=uaksVVHDhYU",
  "videoID": "uaksVVHDhYU",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/intellij-idea-the-documentary.json
+++ b/generated/intellij-idea-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "intellij-idea-the-documentary",
  "link": "https://www.youtube.com/watch?v=Kourq_Lz03U",
  "videoID": "Kourq_Lz03U",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/internet-relay-chat-irc.json
+++ b/generated/internet-relay-chat-irc.json
@@ -3,6 +3,7 @@
  "slug": "internet-relay-chat-irc",
  "link": "https://www.youtube.com/watch?v=6UbKenFipjo",
  "videoID": "6UbKenFipjo",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/kubernetes-the-documentary-part-1.json
+++ b/generated/kubernetes-the-documentary-part-1.json
@@ -3,6 +3,7 @@
  "slug": "kubernetes-the-documentary-part-1",
  "link": "https://www.youtube.com/watch?v=BE77h7dmoQU",
  "videoID": "BE77h7dmoQU",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/kubernetes-the-documentary-part-2.json
+++ b/generated/kubernetes-the-documentary-part-2.json
@@ -3,6 +3,7 @@
  "slug": "kubernetes-the-documentary-part-2",
  "link": "https://www.youtube.com/watch?v=318elIq37PE",
  "videoID": "318elIq37PE",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/laravel-origins-a-php-documentary.json
+++ b/generated/laravel-origins-a-php-documentary.json
@@ -3,6 +3,7 @@
  "slug": "laravel-origins-a-php-documentary",
  "link": "https://www.youtube.com/watch?v=127ng7botO4",
  "videoID": "127ng7botO4",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/node-js-the-documentary.json
+++ b/generated/node-js-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "node-js-the-documentary",
  "link": "https://www.youtube.com/watch?v=LB8KwiiUGy0",
  "videoID": "LB8KwiiUGy0",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/prometheus-the-documentary.json
+++ b/generated/prometheus-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "prometheus-the-documentary",
  "link": "https://www.youtube.com/watch?v=rT4fJNbfe14",
  "videoID": "rT4fJNbfe14",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/python-the-documentary.json
+++ b/generated/python-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "python-the-documentary",
  "link": "https://www.youtube.com/watch?v=GfH4QL4VqJ0",
  "videoID": "GfH4QL4VqJ0",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/react-js-the-documentary.json
+++ b/generated/react-js-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "react-js-the-documentary",
  "link": "https://www.youtube.com/watch?v=8pDqJVdNa44",
  "videoID": "8pDqJVdNa44",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/revolution-os.json
+++ b/generated/revolution-os.json
@@ -3,6 +3,7 @@
  "slug": "revolution-os",
  "link": "https://www.youtube.com/watch?v=k0RYQVkQmWU",
  "videoID": "k0RYQVkQmWU",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/ruby-on-rails-the-documentary.json
+++ b/generated/ruby-on-rails-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "ruby-on-rails-the-documentary",
  "link": "https://www.youtube.com/watch?v=HDKUEXBF3B4",
  "videoID": "HDKUEXBF3B4",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/svelte-origins-a-javascript-documentary.json
+++ b/generated/svelte-origins-a-javascript-documentary.json
@@ -3,6 +3,7 @@
  "slug": "svelte-origins-a-javascript-documentary",
  "link": "https://www.youtube.com/watch?v=kMlkCYL9qo0",
  "videoID": "kMlkCYL9qo0",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/the-internets-own-boy-aaron-swartz.json
+++ b/generated/the-internets-own-boy-aaron-swartz.json
@@ -3,6 +3,7 @@
  "slug": "the-internets-own-boy-the-story-of-aaron-swartz",
  "link": "https://www.youtube.com/watch?v=9vz06QO3UkQ",
  "videoID": "9vz06QO3UkQ",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/typescript-origins-the-documentary.json
+++ b/generated/typescript-origins-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "typescript-origins-the-documentary",
  "link": "https://www.youtube.com/watch?v=U6s2pdxebSo",
  "videoID": "U6s2pdxebSo",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/vite-the-documentary.json
+++ b/generated/vite-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "vite-the-documentary",
  "link": "https://www.youtube.com/watch?v=bmWQqAKLgT4",
  "videoID": "bmWQqAKLgT4",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/vue-js-the-documentary.json
+++ b/generated/vue-js-the-documentary.json
@@ -3,6 +3,7 @@
  "slug": "vue-js-the-documentary",
  "link": "https://www.youtube.com/watch?v=OrxmtDw4pVI",
  "videoID": "OrxmtDw4pVI",
+ "platform": "youtube",
  "language": [
   "en"
  ],

--- a/generated/we-are-legion-the-story-of-the-hacktivists.json
+++ b/generated/we-are-legion-the-story-of-the-hacktivists.json
@@ -3,6 +3,7 @@
  "slug": "we-are-legion-the-story-of-the-hacktivists",
  "link": "https://www.youtube.com/watch?v=4D1WJsdu6W8",
  "videoID": "4D1WJsdu6W8",
+ "platform": "youtube",
  "language": [
   "en"
  ],


### PR DESCRIPTION
## Summary
- Add a \`platform\` field to the generated JSON, populated for every entry. \`youtube\` today; Netflix / Amazon Prime / etc. plug in by extending one tiny package.
- New \`app/platform\` package owns the slugs, the URL→slug detector, and the display-name map. \`Detect\` defers to \`youtube.ParseVideoID\` for the YouTube branch so URL-shape knowledge stays in one place.
- \`platform\` is YAML-overridable like \`description\`/\`imdbID\`: when YAML sets it, the value always wins. The tooling logs a warning when an explicit YAML value disagrees with what the link looks like, when YAML names a platform whose link the detector cannot recognise, or when neither YAML nor the link yields a platform.
- README template now renders \`* [Watch on {{ PlatformDisplay }}](…)\` so a future Netflix entry won't read "Watch on YouTube". Visual no-op today; semantic foundation for tomorrow.

## Why
Every entry today is a YouTube video, but Netflix and Amazon Prime are on the roadmap. The schema needs a \`platform\` field before that variety arrives, otherwise every future PR carries the cost of retrofitting.

## Sample output
\`generated/python-the-documentary.json\` gains:
\`\`\`json
\"platform\": \"youtube\",
\`\`\`

## Commit-by-commit
1. \`app/platform\` package: slugs, \`Detect\`, \`Display\`, full unit tests.
2. Wire platform into the YAML→JSON pipeline: field, merge rule, \`resolvePlatform\` helper with the four warning branches, \`PlatformDisplay\` template helper, tests.
3. README template: \`Watch on {{ PlatformDisplay }}\`.
4. Documentation: \`platform\` row in CONTRIBUTING.md.
5. \`chore: Update generated movie content\`: regenerated JSON + README.

## Test plan
- [x] \`cd app && go build ./... && go vet ./... && go test ./...\` — all passing, including new platform-pkg tests, \`resolvePlatform\` table tests, \`PlatformDisplay\` test, \`mergeMovieInformation\` precedence tests for the new field.
- [x] \`go run . convertYamlToJson …\` — silent on platform warnings (every link autodetected); 26 generated JSONs all gain \`\"platform\": \"youtube\"\`.
- [x] \`go run . convertJsonToReadme …\` — every entry still renders "Watch on YouTube".
- [x] Spot-checked the warning paths manually (YAML mismatch, unknown link, YAML+unknown link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)