### PR TITLE
Add localized per-language overrides to the YAML schema

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,9 +73,27 @@ non-commercial dataset.
 | `tags`        | list[string]   | yes      | YAML            | Subject-matter tags. Be coarse — better to have 3–5 broad tags than 15 narrow ones. |
 | `imdbID`      | string         | no       | YAML            | IMDb tconst (e.g. `tt3268458`). Set this only when the entry is also catalogued on IMDb so the tooling can pull the IMDb rating from the public dataset. Most YouTube documentaries are not on IMDb — leave this unset for those. |
 | `platform`    | string         | no       | YAML > tooling  | Slug of the source the link lives on (`youtube` today). Auto-detected from `link` when omitted; set explicitly only if you need to override the detector or your link is from a source the tooling does not yet recognise. The tooling logs a warning when an explicit platform disagrees with what the link looks like. |
+| `localized`   | map[code → object] | no   | YAML            | Per-language alternate-version overrides. Keys are ISO 639-1 codes (`de`, `es`, …). Each value supports optional `title` and `link` — provide whichever differs from the English `name`/`link` above; the English version is always the rendered default. Alternate links are not enriched (no extra YouTube/IMDb API calls); they round-trip from YAML to JSON unchanged. |
 
 The remaining JSON fields (`title`, `duration`, `publishedAt`,
 `channel`, `ratings`, `views`, `image`, `slug`, `videoID`,
-`platform` when not set in YAML) are produced by the tooling. **Do not edit `README.md` directly** —
+`platform` when not set in YAML) are produced by the tooling.
+
+If your entry has an alternate-language version, add a `localized`
+block — for example:
+
+```yaml
+name: "Python: The Documentary"
+link: https://www.youtube.com/watch?v=GfH4QL4VqJ0
+tags: [Programming Languages, Open Source, History]
+localized:
+  de:
+    title: Pythons Geschichte
+    link: https://www.youtube.com/watch?v=...
+  es:
+    title: La historia de Python
+```
+
+**Do not edit `README.md` directly** —
 it is overwritten on every CI run. To change rendering, update
 `assets/README.template`.

--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -119,6 +119,7 @@ func cmdConvertYamlToJson(cmd *cobra.Command, args []string) error {
 			log.Printf("WARNING: could not parse YouTube video ID from %q in %s", movieInfo.Link, absYamlFilePath)
 		}
 		resolvePlatform(movieInfo, absYamlFilePath)
+		validateLocalized(movieInfo, absYamlFilePath)
 
 		log.Printf("Write %s to disk ...", absJsonFilePath)
 		err = io.WriteJSONFile(absJsonFilePath, movieInfo)
@@ -161,8 +162,42 @@ func mergeMovieInformation(source, target *MovieInformation) *MovieInformation {
 	if len(source.Platform) > 0 {
 		target.Platform = source.Platform
 	}
+	if len(source.Localized) > 0 {
+		target.Localized = source.Localized
+	}
 	target.Tags = source.Tags
 	return target
+}
+
+// validateLocalized inspects info.Localized for the obvious
+// mistakes: a key that does not look like an ISO 639-1 code, or an
+// entry whose title and link are both empty (in which case the key
+// adds nothing to the file). Each problem is logged as a warning so
+// the maintainer notices, but the conversion proceeds — the data
+// shape is still valid YAML.
+//
+// fileLabel is the human-friendly file path for the warning text.
+func validateLocalized(info *MovieInformation, fileLabel string) {
+	for code, v := range info.Localized {
+		if !isISO639_1Like(code) {
+			log.Printf("WARNING: %s: localized language key %q is not a 2-letter lowercase code; expected ISO 639-1",
+				fileLabel, code)
+		}
+		if v.Title == "" && v.Link == "" {
+			log.Printf("WARNING: %s: localized.%s has neither title nor link set; remove the key or fill in at least one field",
+				fileLabel, code)
+		}
+	}
+}
+
+// isISO639_1Like is a cheap shape check, not a registry lookup —
+// catching typos like "DE" or "deu" matters; being authoritative
+// about which two-letter codes are real does not.
+func isISO639_1Like(s string) bool {
+	if len(s) != 2 {
+		return false
+	}
+	return s[0] >= 'a' && s[0] <= 'z' && s[1] >= 'a' && s[1] <= 'z'
 }
 
 // resolvePlatform fills in info.Platform from the link when YAML did

--- a/app/cmd/convertYamlToJson_test.go
+++ b/app/cmd/convertYamlToJson_test.go
@@ -142,6 +142,107 @@ func TestResolvePlatform(t *testing.T) {
 	}
 }
 
+func TestMergeMovieInformation_LocalizedPrecedence(t *testing.T) {
+	t.Run("YAML localized map overrides target", func(t *testing.T) {
+		yaml := &MovieInformation{
+			Name: "n", Link: "l",
+			Localized: map[string]LocalizedVersion{
+				"de": {Title: "from-yaml", Link: "yaml-link"},
+			},
+		}
+		json := &MovieInformation{
+			Name: "stale", Link: "stale",
+			Localized: map[string]LocalizedVersion{
+				"de": {Title: "stale-title", Link: "stale-link"},
+				"es": {Title: "should-be-dropped"},
+			},
+		}
+
+		got := mergeMovieInformation(yaml, json)
+		if len(got.Localized) != 1 {
+			t.Fatalf("Localized = %v; want exactly the YAML map", got.Localized)
+		}
+		if got.Localized["de"].Title != "from-yaml" || got.Localized["de"].Link != "yaml-link" {
+			t.Fatalf("Localized[de] = %+v; want from-yaml/yaml-link", got.Localized["de"])
+		}
+		if _, ok := got.Localized["es"]; ok {
+			t.Errorf("YAML omitting 'es' must drop it; map currently has it")
+		}
+	})
+
+	t.Run("empty YAML localized preserves target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l"} // Localized empty
+		json := &MovieInformation{
+			Name: "stale", Link: "stale",
+			Localized: map[string]LocalizedVersion{
+				"de": {Title: "from-target"},
+			},
+		}
+
+		got := mergeMovieInformation(yaml, json)
+		if len(got.Localized) != 1 || got.Localized["de"].Title != "from-target" {
+			t.Fatalf("Localized = %v; want target preserved", got.Localized)
+		}
+	})
+}
+
+func TestValidateLocalized(t *testing.T) {
+	cases := []struct {
+		name        string
+		localized   map[string]LocalizedVersion
+		wantWarnSub string // empty = expect no warning
+	}{
+		{
+			name: "well-formed entries do not warn",
+			localized: map[string]LocalizedVersion{
+				"de": {Title: "Pythons Geschichte", Link: "https://example.com/de"},
+				"es": {Title: "La historia de Python"},
+				"fr": {Link: "https://example.com/fr"},
+			},
+		},
+		{
+			name:        "uppercase key warns",
+			localized:   map[string]LocalizedVersion{"DE": {Title: "x"}},
+			wantWarnSub: "is not a 2-letter lowercase code",
+		},
+		{
+			name:        "three-letter key warns",
+			localized:   map[string]LocalizedVersion{"deu": {Title: "x"}},
+			wantWarnSub: "is not a 2-letter lowercase code",
+		},
+		{
+			name:        "single-letter key warns",
+			localized:   map[string]LocalizedVersion{"d": {Title: "x"}},
+			wantWarnSub: "is not a 2-letter lowercase code",
+		},
+		{
+			name:        "empty entry warns",
+			localized:   map[string]LocalizedVersion{"de": {}},
+			wantWarnSub: "neither title nor link set",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := &MovieInformation{Localized: tc.localized}
+
+			var buf bytes.Buffer
+			prev := log.Writer()
+			log.SetOutput(&buf)
+			defer log.SetOutput(prev)
+
+			validateLocalized(info, "test.yml")
+
+			out := buf.String()
+			switch {
+			case tc.wantWarnSub == "" && strings.Contains(out, "WARNING"):
+				t.Errorf("expected no warning, got: %s", out)
+			case tc.wantWarnSub != "" && !strings.Contains(out, tc.wantWarnSub):
+				t.Errorf("expected warning containing %q, got: %s", tc.wantWarnSub, out)
+			}
+		})
+	}
+}
+
 func TestMergeMovieInformation_PlatformPrecedence(t *testing.T) {
 	t.Run("YAML platform overrides target", func(t *testing.T) {
 		yaml := &MovieInformation{Name: "n", Link: "l", Platform: "netflix"}

--- a/app/cmd/types.go
+++ b/app/cmd/types.go
@@ -39,6 +39,13 @@ type MovieInformation struct {
 	// with the languages reported by the YouTube captions.list API.
 	Subtitles []string `yaml:"subtitles" json:"subtitles"`
 	Tags      []string `yaml:"tags"      json:"tags"`
+	// Localized maps ISO 639-1 codes (e.g. "de", "es") to per-language
+	// overrides. The top-level Name and Link are always the English
+	// version; entries here describe alternate-language versions of
+	// the same content (a different upload, a translated title, or
+	// both). Optional in YAML; absent for entries that only exist in
+	// one language. Map omits itself from JSON when empty.
+	Localized map[string]LocalizedVersion `yaml:"localized,omitempty" json:"localized,omitempty"`
 
 	// API-enriched fields below this line.
 	Title string `yaml:"-" json:"title"`
@@ -64,6 +71,15 @@ type MovieInformation struct {
 	// in the JSON itself.
 	Views Views  `yaml:"-" json:"views,omitzero"`
 	Image string `yaml:"-" json:"image"`
+}
+
+// LocalizedVersion holds the per-language overrides for one
+// alternate version of an entry. Both fields are individually
+// optional: maintainers fill in whichever differs from the top-level
+// English version (a translated title, a different upload, or both).
+type LocalizedVersion struct {
+	Title string `yaml:"title,omitempty" json:"title,omitempty"`
+	Link  string `yaml:"link,omitempty"  json:"link,omitempty"`
 }
 
 // YouTubeRating holds rating-like signals YouTube exposes via


### PR DESCRIPTION
## Summary
- New optional \`localized\` field on each YAML: a map keyed by ISO 639-1 code (\`de\`, \`es\`, …) holding per-language overrides.
- Each value supports optional \`title\` and \`link\`. Either field can stand alone — translated title for the same video, different upload with the original title, or both.
- Top-level \`name\` and \`link\` continue to mean *the English version*; the README still renders English.
- Alternate links are not enriched (no extra YouTube/IMDb API calls). They round-trip from YAML to JSON unchanged.
- A small \`validateLocalized\` pass warns on the two easy mistakes: a key that is not 2 lowercase letters (e.g. \`DE\`, \`deu\`), or an entry with both \`title\` and \`link\` blank.

## Why
Some entries have alternate-language uploads or translated titles, and the schema had no way to capture that. The new key is \`localized\` (not \`language\`) to avoid colliding with the existing \`language\` list — that field describes audio tracks of one video and is a different concept.

## Target shape

\`\`\`yaml
localized:
  de:
    title: Pythons Geschichte
    link: https://www.youtube.com/watch?v=...
  es:
    title: La historia de Python
\`\`\`

\`\`\`json
\"localized\": {
  \"de\": { \"title\": \"Pythons Geschichte\", \"link\": \"https://www.youtube.com/watch?v=...\" },
  \"es\": { \"title\": \"La historia de Python\" }
}
\`\`\`

The map omits itself when empty, so all 26 current entries serialise identically — no \`generated/*.json\` regen commit is needed.

## Commit-by-commit
1. Schema + validation + tests — \`LocalizedVersion\` type, \`Localized\` field, merge precedence rule, \`validateLocalized\` helper with \`isISO639_1Like\` shape check, two new test functions.
2. Documentation — \`localized\` row in CONTRIBUTING.md plus an inline YAML example.

## Test plan
- [x] \`cd app && go build ./... && go vet ./... && go test ./...\` — all passing, including new \`TestMergeMovieInformation_LocalizedPrecedence\` and \`TestValidateLocalized\`.
- [x] \`go run . convertYamlToJson …\` — zero diff against committed \`generated/*.json\` (no YAML sets the field yet, and it omits when empty).
- [x] Manual round-trip with a sample YAML carrying valid + bad-key + empty \`localized\` entries — got the expected warnings, well-formed entry survived into JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)