### PR TITLE
Strip videoID from generated JSON; keep as a runtime-only field

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,8 @@ non-commercial dataset.
 | `localized`   | map[code → object] | no   | YAML            | Per-language alternate-version overrides. Keys are ISO 639-1 codes (`de`, `es`, …). Each value supports optional `title`, `link`, and `description` — provide whichever differs from the English top-level. A per-localized `platform` is autodetected from the localized `link` (same precedence rules as the top-level `platform`), so a German Amazon Prime link on a YouTube top-level entry is recorded correctly. Alternate links are not enriched (no extra YouTube/IMDb API calls); they round-trip from YAML to JSON unchanged. |
 
 The remaining JSON fields (`title`, `duration`, `publishedAt`,
-`channel`, `ratings`, `views`, `image`, `slug`, `videoID`,
-`platform` when not set in YAML) are produced by the tooling.
+`channel`, `ratings`, `views`, `image`, `slug`, `platform` when
+not set in YAML) are produced by the tooling.
 
 If your entry has an alternate-language version, add a `localized`
 block — for example:

--- a/app/cmd/collectMovieData.go
+++ b/app/cmd/collectMovieData.go
@@ -113,16 +113,19 @@ func cmdCollectMovieData(cmd *cobra.Command, args []string) error {
 		entries = append(entries, entry{path: absJsonFilePath, info: info})
 		// YouTube enrichment runs only on YouTube entries. Other
 		// platforms (Netflix, Amazon Prime Video, bpb, …) do not have
-		// a YouTube video ID by construction; the missing-videoID
-		// warning is a maintainer signal for YouTube entries that
-		// genuinely failed extraction.
+		// a YouTube video ID by construction.
 		if info.Platform != platform.YouTube {
 			continue
 		}
-		if info.VideoID != "" {
-			ids = append(ids, info.VideoID)
+		// VideoID is not persisted in JSON; derive it from Link on
+		// load. The parse-failure warning fires here, where the
+		// failure actually matters (we are about to ask the API for
+		// it).
+		if id, ok := youtube.ParseVideoID(info.Link); ok {
+			info.VideoID = id
+			ids = append(ids, id)
 		} else {
-			log.Printf("WARNING: %s has no videoID; skipping API enrichment", absJsonFilePath)
+			log.Printf("WARNING: could not parse YouTube video ID from %q in %s", info.Link, absJsonFilePath)
 		}
 	}
 

--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/EngineeringKiosk/awesome-software-engineering-movies/io"
 	"github.com/EngineeringKiosk/awesome-software-engineering-movies/platform"
-	"github.com/EngineeringKiosk/awesome-software-engineering-movies/youtube"
 )
 
 // convertYamlToJsonCmd represents the convertYamlToJson command
@@ -117,18 +116,6 @@ func cmdConvertYamlToJson(cmd *cobra.Command, args []string) error {
 		resolvePlatform(movieInfo, absYamlFilePath)
 		resolveLocalizedPlatforms(movieInfo, absYamlFilePath)
 		validateLocalized(movieInfo, absYamlFilePath)
-
-		// VideoID is YouTube-specific. Skip the parse (and its
-		// failure warning) entirely for entries on other platforms;
-		// the warning would otherwise fire on every Netflix / Amazon /
-		// bpb entry on every run.
-		if movieInfo.Platform == platform.YouTube {
-			if id, ok := youtube.ParseVideoID(movieInfo.Link); ok {
-				movieInfo.VideoID = id
-			} else {
-				log.Printf("WARNING: could not parse YouTube video ID from %q in %s", movieInfo.Link, absYamlFilePath)
-			}
-		}
 
 		log.Printf("Write %s to disk ...", absJsonFilePath)
 		err = io.WriteJSONFile(absJsonFilePath, movieInfo)

--- a/app/cmd/types.go
+++ b/app/cmd/types.go
@@ -21,8 +21,12 @@ type MovieInformation struct {
 	Slug string `yaml:"-" json:"slug"`
 
 	Link string `yaml:"link" json:"link"`
-	// VideoID is parsed from Link by convertYamlToJson.
-	VideoID string `yaml:"-" json:"videoID"`
+	// VideoID is YouTube-specific and lives only as a runtime field:
+	// not persisted to JSON, not curated in YAML. collectMovieData
+	// derives it from Link on load via youtube.ParseVideoID and uses
+	// it for the videos.list API call, the response→entry join, and
+	// the thumbnail URL. Other platforms leave it empty.
+	VideoID string `yaml:"-" json:"-"`
 	// Platform identifies which source the link lives on (e.g.
 	// "youtube"). Optional in YAML — convertYamlToJson auto-fills it
 	// from the link via the platform package when omitted. The YAML

--- a/generated/angular-the-documentary.json
+++ b/generated/angular-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "Angular: The Documentary",
  "slug": "angular-the-documentary",
  "link": "https://www.youtube.com/watch?v=cRC9DlH45lA",
- "videoID": "cRC9DlH45lA",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/clojure-the-documentary.json
+++ b/generated/clojure-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "Clojure: The Documentary",
  "slug": "clojure-the-documentary",
  "link": "https://www.youtube.com/watch?v=Y24vK_QDLFg",
- "videoID": "Y24vK_QDLFg",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/code-debugging-the-gender-gap.json
+++ b/generated/code-debugging-the-gender-gap.json
@@ -2,7 +2,6 @@
  "name": "CODE: Debugging the Gender Gap",
  "slug": "code-debugging-the-gender-gap",
  "link": "https://www.youtube.com/watch?v=rQKRw6tWsb8",
- "videoID": "rQKRw6tWsb8",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/ebpf-unlocking-the-kernel.json
+++ b/generated/ebpf-unlocking-the-kernel.json
@@ -2,7 +2,6 @@
  "name": "eBPF: Unlocking the Kernel",
  "slug": "ebpf-unlocking-the-kernel",
  "link": "https://www.youtube.com/watch?v=Wb_vD3XZYOA",
- "videoID": "Wb_vD3XZYOA",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/elixir-the-documentary.json
+++ b/generated/elixir-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "Elixir: The Documentary",
  "slug": "elixir-the-documentary",
  "link": "https://www.youtube.com/watch?v=lxYFOM3UJzo",
- "videoID": "lxYFOM3UJzo",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/ember-js-the-documentary.json
+++ b/generated/ember-js-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "Ember.js: The Documentary",
  "slug": "ember-js-the-documentary",
  "link": "https://www.youtube.com/watch?v=Cvz-9ccflKQ",
- "videoID": "Cvz-9ccflKQ",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/graphql-the-documentary.json
+++ b/generated/graphql-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "GraphQL: The Documentary",
  "slug": "graphql-the-documentary",
  "link": "https://www.youtube.com/watch?v=783ccP__No8",
- "videoID": "783ccP__No8",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/half-life-25th-anniversary-documentary.json
+++ b/generated/half-life-25th-anniversary-documentary.json
@@ -2,7 +2,6 @@
  "name": "Half-Life: 25th Anniversary Documentary",
  "slug": "half-life-25th-anniversary-documentary",
  "link": "https://www.youtube.com/watch?v=TbZ3HzvFEto",
- "videoID": "TbZ3HzvFEto",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/indie-game-the-movie.json
+++ b/generated/indie-game-the-movie.json
@@ -2,7 +2,6 @@
  "name": "Indie Game: The Movie",
  "slug": "indie-game-the-movie",
  "link": "https://www.netflix.com/title/70229918",
- "videoID": "",
  "platform": "netflix",
  "language": null,
  "subtitles": null,

--- a/generated/inside-envoy.json
+++ b/generated/inside-envoy.json
@@ -2,7 +2,6 @@
  "name": "Inside Envoy: The Proxy for the Future",
  "slug": "inside-envoy-the-proxy-for-the-future",
  "link": "https://www.youtube.com/watch?v=uaksVVHDhYU",
- "videoID": "uaksVVHDhYU",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/intellij-idea-the-documentary.json
+++ b/generated/intellij-idea-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "IntelliJ IDEA: The Documentary",
  "slug": "intellij-idea-the-documentary",
  "link": "https://www.youtube.com/watch?v=Kourq_Lz03U",
- "videoID": "Kourq_Lz03U",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/internet-relay-chat-irc.json
+++ b/generated/internet-relay-chat-irc.json
@@ -2,7 +2,6 @@
  "name": "Internet Relay Chat (IRC)",
  "slug": "internet-relay-chat-irc",
  "link": "https://www.youtube.com/watch?v=6UbKenFipjo",
- "videoID": "6UbKenFipjo",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/kubernetes-the-documentary-part-1.json
+++ b/generated/kubernetes-the-documentary-part-1.json
@@ -2,7 +2,6 @@
  "name": "Kubernetes: The Documentary [PART 1]",
  "slug": "kubernetes-the-documentary-part-1",
  "link": "https://www.youtube.com/watch?v=BE77h7dmoQU",
- "videoID": "BE77h7dmoQU",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/kubernetes-the-documentary-part-2.json
+++ b/generated/kubernetes-the-documentary-part-2.json
@@ -2,7 +2,6 @@
  "name": "Kubernetes: The Documentary [PART 2]",
  "slug": "kubernetes-the-documentary-part-2",
  "link": "https://www.youtube.com/watch?v=318elIq37PE",
- "videoID": "318elIq37PE",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/laravel-origins-a-php-documentary.json
+++ b/generated/laravel-origins-a-php-documentary.json
@@ -2,7 +2,6 @@
  "name": "Laravel Origins: A PHP Documentary",
  "slug": "laravel-origins-a-php-documentary",
  "link": "https://www.youtube.com/watch?v=127ng7botO4",
- "videoID": "127ng7botO4",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/lo-and-behold-reveries-of-the-connected-world.json
+++ b/generated/lo-and-behold-reveries-of-the-connected-world.json
@@ -2,7 +2,6 @@
  "name": "Lo and Behold: Reveries of the Connected World",
  "slug": "lo-and-behold-reveries-of-the-connected-world",
  "link": "https://www.youtube.com/watch?v=q3g3hqNJqpQ",
- "videoID": "q3g3hqNJqpQ",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/node-js-the-documentary.json
+++ b/generated/node-js-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "Node.js: The Documentary",
  "slug": "node-js-the-documentary",
  "link": "https://www.youtube.com/watch?v=LB8KwiiUGy0",
- "videoID": "LB8KwiiUGy0",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/prometheus-the-documentary.json
+++ b/generated/prometheus-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "Prometheus: The Documentary",
  "slug": "prometheus-the-documentary",
  "link": "https://www.youtube.com/watch?v=rT4fJNbfe14",
- "videoID": "rT4fJNbfe14",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/python-the-documentary.json
+++ b/generated/python-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "Python: The Documentary",
  "slug": "python-the-documentary",
  "link": "https://www.youtube.com/watch?v=GfH4QL4VqJ0",
- "videoID": "GfH4QL4VqJ0",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/react-js-the-documentary.json
+++ b/generated/react-js-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "React.js: The Documentary",
  "slug": "react-js-the-documentary",
  "link": "https://www.youtube.com/watch?v=8pDqJVdNa44",
- "videoID": "8pDqJVdNa44",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/revolution-os.json
+++ b/generated/revolution-os.json
@@ -2,7 +2,6 @@
  "name": "Revolution OS",
  "slug": "revolution-os",
  "link": "https://www.youtube.com/watch?v=k0RYQVkQmWU",
- "videoID": "k0RYQVkQmWU",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/ruby-on-rails-the-documentary.json
+++ b/generated/ruby-on-rails-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "Ruby on Rails: The Documentary",
  "slug": "ruby-on-rails-the-documentary",
  "link": "https://www.youtube.com/watch?v=HDKUEXBF3B4",
- "videoID": "HDKUEXBF3B4",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/silicon-cowboys.json
+++ b/generated/silicon-cowboys.json
@@ -2,7 +2,6 @@
  "name": "Silicon Cowboys",
  "slug": "silicon-cowboys",
  "link": "https://www.netflix.com/title/80104318",
- "videoID": "",
  "platform": "netflix",
  "language": null,
  "subtitles": null,

--- a/generated/svelte-origins-a-javascript-documentary.json
+++ b/generated/svelte-origins-a-javascript-documentary.json
@@ -2,7 +2,6 @@
  "name": "Svelte Origins: A JavaScript Documentary",
  "slug": "svelte-origins-a-javascript-documentary",
  "link": "https://www.youtube.com/watch?v=kMlkCYL9qo0",
- "videoID": "kMlkCYL9qo0",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/terms-and-conditions-may-apply.json
+++ b/generated/terms-and-conditions-may-apply.json
@@ -2,7 +2,6 @@
  "name": "Terms and Conditions May Apply",
  "slug": "terms-and-conditions-may-apply",
  "link": "https://www.youtube.com/watch?v=hRJEYmodC08",
- "videoID": "hRJEYmodC08",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/the-cleaners.json
+++ b/generated/the-cleaners.json
@@ -2,7 +2,6 @@
  "name": "The Cleaners",
  "slug": "the-cleaners",
  "link": "https://www.bpb.de/mediathek/video/273199/the-cleaners/",
- "videoID": "",
  "platform": "bpb",
  "language": null,
  "subtitles": null,

--- a/generated/the-great-hack.json
+++ b/generated/the-great-hack.json
@@ -2,7 +2,6 @@
  "name": "The Great Hack",
  "slug": "the-great-hack",
  "link": "https://www.netflix.com/title/80117542",
- "videoID": "",
  "platform": "netflix",
  "language": [
   "en",

--- a/generated/the-internets-own-boy-aaron-swartz.json
+++ b/generated/the-internets-own-boy-aaron-swartz.json
@@ -2,7 +2,6 @@
  "name": "The Internet's Own Boy: The Story of Aaron Swartz",
  "slug": "the-internets-own-boy-the-story-of-aaron-swartz",
  "link": "https://www.youtube.com/watch?v=9vz06QO3UkQ",
- "videoID": "9vz06QO3UkQ",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/typescript-origins-the-documentary.json
+++ b/generated/typescript-origins-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "TypeScript Origins: The Documentary",
  "slug": "typescript-origins-the-documentary",
  "link": "https://www.youtube.com/watch?v=U6s2pdxebSo",
- "videoID": "U6s2pdxebSo",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/vite-the-documentary.json
+++ b/generated/vite-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "VITE: The Documentary",
  "slug": "vite-the-documentary",
  "link": "https://www.youtube.com/watch?v=bmWQqAKLgT4",
- "videoID": "bmWQqAKLgT4",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/vue-js-the-documentary.json
+++ b/generated/vue-js-the-documentary.json
@@ -2,7 +2,6 @@
  "name": "Vue.js: The Documentary",
  "slug": "vue-js-the-documentary",
  "link": "https://www.youtube.com/watch?v=OrxmtDw4pVI",
- "videoID": "OrxmtDw4pVI",
  "platform": "youtube",
  "language": [
   "en"

--- a/generated/we-are-legion-the-story-of-the-hacktivists.json
+++ b/generated/we-are-legion-the-story-of-the-hacktivists.json
@@ -2,7 +2,6 @@
  "name": "We Are Legion: The Story of the Hacktivists",
  "slug": "we-are-legion-the-story-of-the-hacktivists",
  "link": "https://www.youtube.com/watch?v=4D1WJsdu6W8",
- "videoID": "4D1WJsdu6W8",
  "platform": "youtube",
  "language": [
   "en"


### PR DESCRIPTION
## Summary
- \`videoID\` is no longer persisted to \`generated/*.json\`. Every file loses one line; nothing else changes.
- The field stays on \`MovieInformation\` as a runtime-only value (\`json:\"-\"\`); collectMovieData derives it from \`Link\` on load via \`youtube.ParseVideoID\` for the YouTube enrichment path.
- The parse-failure warning moves from convertYamlToJson to collectMovieData — fires at the moment the failure actually matters (right before the API call), not at YAML→JSON time when nothing depends on it yet.

## Why
Nothing in this repo reads \`videoID\` back from the generated JSON. The YouTube SDK call, the response→entry join, and the thumbnail URL all live inside collectMovieData, right next to the parser that produces the value. For non-YouTube entries (Netflix, Amazon Prime Video, bpb) the field serialised as \`\"videoID\": \"\"\`, which was pure noise.

## Commit-by-commit
1. Make videoID a runtime-only field — tag change in \`types.go\`, drop the parse from \`convertYamlToJson.go\`, add the parse-on-load (and warning) in \`collectMovieData.go\`.
2. Documentation — drop \`videoID\` from CONTRIBUTING.md's tooling-produced fields list.
3. \`chore: Update generated movie content\` — every JSON loses one line; README unchanged.

## Test plan
- [x] \`cd app && go build ./... && go vet ./... && go test ./...\`
- [x] \`go run . convertYamlToJson …\` — every regenerated JSON loses its videoID line; no warnings.
- [x] Spot-checked a YouTube and a non-YouTube entry's diffs: pure single-line removals.
- [x] README regenerates with zero diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)