### PR TITLE
Make title / duration / publishedAt YAML-curatable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,13 @@ non-commercial dataset.
 | `platform`    | string         | no       | YAML > tooling  | Slug of the source the link lives on (`youtube`, `netflix`, `amazon_prime_video`, `bpb`). Auto-detected from `link` when omitted; set explicitly only if you need to override the detector or your link is from a source the tooling does not yet recognise. The tooling logs a warning when an explicit platform disagrees with what the link looks like. |
 | `localized`   | map[code → object] | no   | YAML            | Per-language alternate-version overrides. Keys are ISO 639-1 codes (`de`, `es`, …). Each value supports optional `title`, `link`, and `description` — provide whichever differs from the English top-level. A per-localized `platform` is autodetected from the localized `link` (same precedence rules as the top-level `platform`), so a German Amazon Prime link on a YouTube top-level entry is recorded correctly. Alternate links are not enriched (no extra YouTube/IMDb API calls); they round-trip from YAML to JSON unchanged. |
 | `youtubeTrailerForThumbnail` | string (YouTube URL) | no | YAML | Fallback YouTube URL the tooling uses for the poster image when the primary `link` is not a YouTube video, or when the primary YouTube thumbnail download fails. Set this for Netflix / Amazon Prime / bpb entries that have a YouTube trailer so the README still gets a poster. If neither the primary link nor this trailer yields an image, the tooling falls back to a bundled placeholder. |
+| `title`       | string         | no       | YAML > API      | Optional override of the entry's title. If omitted, the tooling uses the YouTube API's `snippet.title`. Set explicitly for non-YouTube entries (Netflix, bpb, …) where there is no API title, or to override an unhelpful upload title. Note that the README's heading is driven by `name`; `title` is for the JSON and downstream consumers. |
+| `duration`    | string (ISO-8601) | no    | YAML > API      | Optional override of the entry's runtime, format `PT[xH][yM][zS]` (e.g. `PT1H54M`). API-supplied for YouTube entries; set manually for non-YouTube entries so the README can render `Duration: ca. X min.` |
+| `publishedAt` | string (RFC3339)  | no    | YAML > API      | Optional override of the entry's release / upload date (e.g. `2019-07-24T00:00:00Z`). API-supplied for YouTube entries; set manually for non-YouTube entries to record the release date. |
 
-The remaining JSON fields (`title`, `duration`, `publishedAt`,
-`channel`, `ratings`, `views`, `image`, `slug`, `platform` when
-not set in YAML) are produced by the tooling.
+The remaining JSON fields (`channel`, `ratings`, `views`, `image`,
+`slug`, `platform` when not set in YAML) are produced by the
+tooling.
 
 If your entry has an alternate-language version, add a `localized`
 block — for example:

--- a/app/cmd/collectMovieData.go
+++ b/app/cmd/collectMovieData.go
@@ -169,9 +169,19 @@ func cmdCollectMovieData(cmd *cobra.Command, args []string) error {
 		if !ok {
 			log.Printf("WARNING: YouTube returned no record for %s (%s); keeping cached values", info.Name, info.VideoID)
 		} else {
-			info.Title = v.Title
-			info.Duration = v.Duration
-			info.PublishedAt = v.PublishedAt
+			// Title / Duration / PublishedAt are YAML-overridable
+			// (same precedence as Description below): only fall back
+			// to the API value when the YAML and the cached value are
+			// both empty.
+			if len(info.Title) == 0 {
+				info.Title = v.Title
+			}
+			if len(info.Duration) == 0 {
+				info.Duration = v.Duration
+			}
+			if len(info.PublishedAt) == 0 {
+				info.PublishedAt = v.PublishedAt
+			}
 			info.Channel = v.Channel
 
 			views := v.ViewCount

--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -152,6 +152,15 @@ func mergeMovieInformation(source, target *MovieInformation) *MovieInformation {
 	if len(source.Description) > 0 {
 		target.Description = source.Description
 	}
+	if len(source.Title) > 0 {
+		target.Title = source.Title
+	}
+	if len(source.Duration) > 0 {
+		target.Duration = source.Duration
+	}
+	if len(source.PublishedAt) > 0 {
+		target.PublishedAt = source.PublishedAt
+	}
 	if len(source.IMDbID) > 0 {
 		target.IMDbID = source.IMDbID
 	}

--- a/app/cmd/convertYamlToJson_test.go
+++ b/app/cmd/convertYamlToJson_test.go
@@ -33,6 +33,72 @@ func TestMergeMovieInformation_DescriptionPrecedence(t *testing.T) {
 	})
 }
 
+func TestMergeMovieInformation_TitlePrecedence(t *testing.T) {
+	t.Run("YAML title overrides target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l", Title: "from-yaml"}
+		json := &MovieInformation{Name: "stale", Link: "stale", Title: "from-api"}
+
+		got := mergeMovieInformation(yaml, json)
+		if got.Title != "from-yaml" {
+			t.Fatalf("Title = %q; want %q", got.Title, "from-yaml")
+		}
+	})
+
+	t.Run("empty YAML title preserves target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l"}
+		json := &MovieInformation{Name: "stale", Link: "stale", Title: "from-api"}
+
+		got := mergeMovieInformation(yaml, json)
+		if got.Title != "from-api" {
+			t.Fatalf("Title = %q; want %q (target preserved)", got.Title, "from-api")
+		}
+	})
+}
+
+func TestMergeMovieInformation_DurationPrecedence(t *testing.T) {
+	t.Run("YAML duration overrides target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l", Duration: "PT1H54M"}
+		json := &MovieInformation{Name: "stale", Link: "stale", Duration: "PT2H"}
+
+		got := mergeMovieInformation(yaml, json)
+		if got.Duration != "PT1H54M" {
+			t.Fatalf("Duration = %q; want %q", got.Duration, "PT1H54M")
+		}
+	})
+
+	t.Run("empty YAML duration preserves target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l"}
+		json := &MovieInformation{Name: "stale", Link: "stale", Duration: "PT2H"}
+
+		got := mergeMovieInformation(yaml, json)
+		if got.Duration != "PT2H" {
+			t.Fatalf("Duration = %q; want %q (target preserved)", got.Duration, "PT2H")
+		}
+	})
+}
+
+func TestMergeMovieInformation_PublishedAtPrecedence(t *testing.T) {
+	t.Run("YAML publishedAt overrides target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l", PublishedAt: "2019-07-24T00:00:00Z"}
+		json := &MovieInformation{Name: "stale", Link: "stale", PublishedAt: "2019-01-01T00:00:00Z"}
+
+		got := mergeMovieInformation(yaml, json)
+		if got.PublishedAt != "2019-07-24T00:00:00Z" {
+			t.Fatalf("PublishedAt = %q; want %q", got.PublishedAt, "2019-07-24T00:00:00Z")
+		}
+	})
+
+	t.Run("empty YAML publishedAt preserves target", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Link: "l"}
+		json := &MovieInformation{Name: "stale", Link: "stale", PublishedAt: "2019-01-01T00:00:00Z"}
+
+		got := mergeMovieInformation(yaml, json)
+		if got.PublishedAt != "2019-01-01T00:00:00Z" {
+			t.Fatalf("PublishedAt = %q; want %q (target preserved)", got.PublishedAt, "2019-01-01T00:00:00Z")
+		}
+	})
+}
+
 func TestMergeMovieInformation_LanguagePrecedence(t *testing.T) {
 	t.Run("YAML language overrides target", func(t *testing.T) {
 		yaml := &MovieInformation{Name: "n", Link: "l", Language: []string{"de"}}

--- a/app/cmd/types.go
+++ b/app/cmd/types.go
@@ -51,8 +51,15 @@ type MovieInformation struct {
 	// one language. Map omits itself from JSON when empty.
 	Localized map[string]LocalizedVersion `yaml:"localized,omitempty" json:"localized,omitempty"`
 
-	// API-enriched fields below this line.
-	Title string `yaml:"-" json:"title"`
+	// API-enriched fields below this line. Some are also YAML-
+	// overridable (title, description, duration, publishedAt) for
+	// entries that have no YouTube API to fall back on.
+	// Title is optional in YAML. If supplied, the YAML value
+	// overrides whatever the YouTube API returns; if omitted, the
+	// API's snippet.title is used. Same precedence rule as
+	// Description. Set explicitly for non-YouTube entries (Netflix,
+	// bpb, …) where there is no API title.
+	Title string `yaml:"title,omitempty" json:"title"`
 	// Description is optional in YAML. If supplied, the YAML value
 	// overrides whatever the YouTube API returns; if omitted, the
 	// API's snippet.description is used. Same precedence rule as
@@ -70,10 +77,17 @@ type MovieInformation struct {
 	// pulls hqdefault.jpg / maxresdefault.jpg via the i.ytimg.com
 	// URL pattern. If neither path yields an image, the README
 	// renders a bundled placeholder.
-	YouTubeTrailerForThumbnail string          `yaml:"youtubeTrailerForThumbnail,omitempty" json:"youtubeTrailerForThumbnail,omitempty"`
-	Duration                   string          `yaml:"-"                                    json:"duration"` // ISO-8601, e.g. PT43M22S
-	PublishedAt                string          `yaml:"-" json:"publishedAt"`
-	Channel                    youtube.Channel `yaml:"-" json:"channel"`
+	YouTubeTrailerForThumbnail string `yaml:"youtubeTrailerForThumbnail,omitempty" json:"youtubeTrailerForThumbnail,omitempty"`
+	// Duration is optional in YAML; format is ISO-8601 like the YouTube
+	// API emits (PT[xH][yM][zS], e.g. PT1H54M). YAML > API precedence,
+	// matching Description. Set manually for non-YouTube entries so the
+	// README can render "Duration: ca. X min."
+	Duration string `yaml:"duration,omitempty" json:"duration"`
+	// PublishedAt is optional in YAML; RFC3339 timestamp matching the
+	// YouTube API's snippet.publishedAt. YAML > API precedence. Set
+	// manually for non-YouTube entries to record the release date.
+	PublishedAt string          `yaml:"publishedAt,omitempty" json:"publishedAt"`
+	Channel     youtube.Channel `yaml:"-"                     json:"channel"`
 	// Ratings groups rating signals by source. Today only YouTube is
 	// populated (likeCount); a future second source — e.g. an external
 	// review aggregator — would slot in as another key.


### PR DESCRIPTION
## Summary
- The three API-only fields \`title\`, \`duration\`, \`publishedAt\` are now YAML-curatable, mirroring the existing \`description\` precedence (YAML wins when set, API fills in otherwise).
- Tag changes in \`MovieInformation\`, three new override-when-set rules in \`mergeMovieInformation\`, three guards in \`collectMovieData\`'s enrichment branch, three precedence tests.
- CONTRIBUTING.md gains explicit rows for each field; the implicit \"tooling-produced fields\" sentence drops them.
- No YAML or generated content edited — enabling curation, not performing it.

## Why
Non-YouTube entries (Netflix / bpb / Amazon Prime Video) have no YouTube API to fall back on, so these three fields have always shipped as empty strings for them. Letting YAML supply the values is the smallest change that lets a maintainer fill them in.

## Report: entries currently missing these fields
Scan of \`generated/*.json\`:

| Slug | Empty fields |
|---|---|
| \`the-great-hack\` | \`title\`, \`duration\`, \`publishedAt\` |
| \`the-cleaners\` | \`title\`, \`duration\`, \`publishedAt\` |
| \`indie-game-the-movie\` | \`title\`, \`duration\`, \`publishedAt\` |
| \`silicon-cowboys\` | \`title\`, \`duration\`, \`publishedAt\` |

All four are non-YouTube. The other 28 entries (YouTube primary link) have all three fields populated by the API. After this PR a maintainer can set the three values in any of the four YAMLs; in the meantime the README continues to render those entries gracefully via its existing \`{{ if … }}\` guards.

## Commit-by-commit
1. Schema + precedence — tag changes in \`types.go\`, three new rules in \`mergeMovieInformation\`, three guards in \`collectMovieData\`, three precedence tests.
2. Documentation — rows for \`title\`/\`duration\`/\`publishedAt\` in CONTRIBUTING.md; corresponding cleanup of the \"tooling-produced fields\" sentence.

## Test plan
- [x] \`cd app && go build ./... && go vet ./... && go test ./...\` — all passing, including three new precedence tests.
- [x] \`go run . convertYamlToJson …\` — zero diff against committed \`generated/*.json\` (no YAML supplies the new fields yet).
- [x] Spot-checked the JSON tag changes round-trip through the existing read/write cycle.

## Note on the \"API stops refreshing\" quirk
The new precedence inherits the same long-standing behaviour that \`Description\` has: once a field is non-empty (from YAML or from a prior API run), the API does not re-overwrite it. Reworking that to \"refresh from API unless YAML explicitly set\" needs a marker on the struct distinguishing YAML-supplied from API-cached values — a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)