### PR TITLE
Replace single `link` with a per-platform `links` map

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,12 +40,17 @@ Out of scope for now:
 
    ```yaml
    name: "Inside Envoy: The Proxy for the Future"
-   link: https://www.youtube.com/watch?v=uaksVVHDhYU
+   links:
+     youtube: https://www.youtube.com/watch?v=uaksVVHDhYU
    tags:
      - Networking
      - Service Mesh
      - Open Source
    ```
+
+   `links` is a map keyed by platform slug — list every platform
+   the entry is available on (`youtube`, `netflix`, `amazon_prime_video`,
+   `bpb`).
 
    `language` is optional — see the field reference below.
 
@@ -67,39 +72,41 @@ non-commercial dataset.
 | Field      | Type           | Required | Source of truth | Notes |
 |------------|----------------|----------|-----------------|-------|
 | `name`     | string         | yes      | YAML            | Drives the slug, filename and README anchor. Keep it close to the YouTube title but cleaned up if needed. |
-| `link`     | string (URL)   | yes      | YAML            | YouTube URL — `youtube.com/watch?v=…`, `youtu.be/…`, `/embed/…`, `/shorts/…` are all accepted. |
+| `links`    | map[slug → URL] | yes     | YAML            | Map of every platform the entry is available on, keyed by platform slug (`youtube`, `netflix`, `amazon_prime_video`, `bpb`). At least one entry required. The tooling validates known-slug URLs against the slug they claim to be and warns on mismatch. Unknown slugs are accepted (a maintainer may pre-declare a platform before its detector lands). |
 | `language`    | list[string]   | no       | YAML > API      | ISO 639-1 codes (`en`, `de`, `fr`, …). If omitted, the tooling falls back to the YouTube `defaultAudioLanguage` and stores it as a single-element list. Set it manually when the API returns nothing or when the video has multiple audio languages. |
 | `description` | string         | no       | YAML > API      | Free text. If omitted, the tooling uses the video's YouTube description. Set it manually when the YouTube description is empty, full of unrelated boilerplate, or otherwise unhelpful for skim-reading the README. |
 | `tags`        | list[string]   | yes      | YAML            | Subject-matter tags. Be coarse — better to have 3–5 broad tags than 15 narrow ones. |
 | `imdbID`      | string         | no       | YAML            | IMDb tconst (e.g. `tt3268458`). Set this only when the entry is also catalogued on IMDb so the tooling can pull the IMDb rating from the public dataset. Most YouTube documentaries are not on IMDb — leave this unset for those. |
-| `platform`    | string         | no       | YAML > tooling  | Slug of the source the link lives on (`youtube`, `netflix`, `amazon_prime_video`, `bpb`). Auto-detected from `link` when omitted; set explicitly only if you need to override the detector or your link is from a source the tooling does not yet recognise. The tooling logs a warning when an explicit platform disagrees with what the link looks like. |
-| `localized`   | map[code → object] | no   | YAML            | Per-language alternate-version overrides. Keys are ISO 639-1 codes (`de`, `es`, …). Each value supports optional `title`, `link`, and `description` — provide whichever differs from the English top-level. A per-localized `platform` is autodetected from the localized `link` (same precedence rules as the top-level `platform`), so a German Amazon Prime link on a YouTube top-level entry is recorded correctly. Alternate links are not enriched (no extra YouTube/IMDb API calls); they round-trip from YAML to JSON unchanged. |
-| `youtubeTrailerForThumbnail` | string (YouTube URL) | no | YAML | Fallback YouTube URL the tooling uses for the poster image when the primary `link` is not a YouTube video, or when the primary YouTube thumbnail download fails. Set this for Netflix / Amazon Prime / bpb entries that have a YouTube trailer so the README still gets a poster. If neither the primary link nor this trailer yields an image, the tooling falls back to a bundled placeholder. |
+| `localized`   | map[code → object] | no   | YAML            | Per-language alternate-version overrides. Keys are ISO 639-1 codes (`de`, `es`, …). Each value supports optional `title`, `description`, and `links` (same shape as the top-level `links` map) — provide whichever differs from the English top-level. The `links` override is per-key: only the platform slugs you list override their top-level counterparts; every other top-level platform is inherited unchanged. Alternate links are not enriched (no extra YouTube/IMDb API calls); they round-trip from YAML to JSON unchanged. |
+| `youtubeTrailerForThumbnail` | string (YouTube URL) | no | YAML | Fallback YouTube URL the tooling uses for the poster image when the entry's `links` map has no `youtube` key (or the primary YouTube thumbnail download fails). Set this for Netflix / Amazon Prime / bpb entries that have a YouTube trailer so the README still gets a poster. If neither the primary YouTube link nor this trailer yields an image, the tooling falls back to a bundled placeholder. |
 | `title`       | string         | no       | YAML > API      | Optional override of the entry's title. If omitted, the tooling uses the YouTube API's `snippet.title`. Set explicitly for non-YouTube entries (Netflix, bpb, …) where there is no API title, or to override an unhelpful upload title. Note that the README's heading is driven by `name`; `title` is for the JSON and downstream consumers. |
 | `duration`    | string (ISO-8601) | no    | YAML > API      | Optional override of the entry's runtime, format `PT[xH][yM][zS]` (e.g. `PT1H54M`). API-supplied for YouTube entries; set manually for non-YouTube entries so the README can render `Duration: ca. X min.` |
 | `publishedAt` | string (RFC3339)  | no    | YAML > API      | Optional override of the entry's release / upload date (e.g. `2019-07-24T00:00:00Z`). API-supplied for YouTube entries; set manually for non-YouTube entries to record the release date. |
 
 The remaining JSON fields (`channel`, `ratings`, `views`, `image`,
-`slug`, `platform` when not set in YAML) are produced by the
-tooling.
+`slug`) are produced by the tooling.
 
 If your entry has an alternate-language version, add a `localized`
 block — for example:
 
 ```yaml
 name: "Lo and Behold: Reveries of the Connected World"
-link: https://www.youtube.com/watch?v=q3g3hqNJqpQ
+links:
+  youtube: https://www.youtube.com/watch?v=q3g3hqNJqpQ
 tags: [Internet, History, Society]
 localized:
   de:
     title: Wovon träumt das Internet?
-    link: https://www.amazon.de/gp/video/detail/B0FVCKCM81/
     description: Die Dokumentation beleuchtet die Evolution des Internets ...
+    links:
+      amazon_prime_video: https://www.amazon.de/gp/video/detail/B0FVCKCM81/
 ```
 
-Note that the German version above lives on a different platform
-(`amazon_prime_video`) than the English top-level (`youtube`) — the
-tooling autodetects each.
+The German version above adds a different platform
+(`amazon_prime_video`) without touching the English top-level
+`youtube` link — that's the per-key merge: the German viewer sees
+both the English YouTube upload and the German Amazon Prime
+upload.
 
 **Do not edit `README.md` directly** —
 it is overwritten on every CI run. To change rendering, update

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ From Angular 2 to Ivy, incorporating Signals to converging with Wiz and ...
 * Language: en
 * Tags: Frontend, JavaScript, Google, Open Source, History
 * YouTube likes: 3,546
-* [Watch on YouTube](https://www.youtube.com/watch?v=cRC9DlH45lA)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=cRC9DlH45lA)
 ----
 
 <h3 id="clojure-the-documentary">Clojure: The Documentary</h3>
@@ -77,8 +76,7 @@ Railway is the all-in-one intelligent cloud ...
 * Language: en
 * Tags: Programming Languages, Functional Programming, Open Source, History
 * YouTube likes: 3,590
-* [Watch on YouTube](https://www.youtube.com/watch?v=Y24vK_QDLFg)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=Y24vK_QDLFg)
 ----
 
 <h3 id="code-debugging-the-gender-gap">CODE: Debugging the Gender Gap</h3>
@@ -94,8 +92,7 @@ Tech jobs are growing three times faster than our colleges are producing compute
 * Tags: Girls, STEM, Women in Tech
 * IMDb rating: 6.2 / 10 (337 votes)
 * YouTube likes: 50
-* [Watch on YouTube](https://www.youtube.com/watch?v=rQKRw6tWsb8)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=rQKRw6tWsb8)
 ----
 
 <h3 id="ebpf-unlocking-the-kernel">eBPF: Unlocking the Kernel</h3>
@@ -110,8 +107,7 @@ In 2014, a group of engineers at Plumgrid needed to find an innovative and cost-
 * Language: en
 * Tags: Linux, Kernel, Open Source, Networking
 * YouTube likes: 4,777
-* [Watch on YouTube](https://www.youtube.com/watch?v=Wb_vD3XZYOA)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=Wb_vD3XZYOA)
 ----
 
 <h3 id="elixir-the-documentary">Elixir: The Documentary</h3>
@@ -128,8 +124,7 @@ Check out the ...
 * Language: en
 * Tags: Programming Languages, Functional Programming, Open Source, History
 * YouTube likes: 8,058
-* [Watch on YouTube](https://www.youtube.com/watch?v=lxYFOM3UJzo)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=lxYFOM3UJzo)
 ----
 
 <h3 id="ember-js-the-documentary">Ember.js: The Documentary</h3>
@@ -150,8 +145,7 @@ Facebook: https://www.facebook. ...
 * Language: en
 * Tags: Frontend, JavaScript, Open Source, History
 * YouTube likes: 2,453
-* [Watch on YouTube](https://www.youtube.com/watch?v=Cvz-9ccflKQ)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=Cvz-9ccflKQ)
 ----
 
 <h3 id="graphql-the-documentary">GraphQL: The Documentary</h3>
@@ -168,8 +162,7 @@ Check out the home for untold developer stories around open source, careers and 
 * Language: en
 * Tags: API, Open Source, History
 * YouTube likes: 15,214
-* [Watch on YouTube](https://www.youtube.com/watch?v=783ccP__No8)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=783ccP__No8)
 ----
 
 <h3 id="half-life-25th-anniversary-documentary">Half-Life: 25th Anniversary Documentary</h3>
@@ -196,8 +189,7 @@ Check out the Half-Life 25th Anniversary Update, restored content, new multiplay
 * Language: en
 * Tags: Game Development, Valve, History
 * YouTube likes: 280,107
-* [Watch on YouTube](https://www.youtube.com/watch?v=TbZ3HzvFEto)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=TbZ3HzvFEto)
 ----
 
 <h3 id="indie-game-the-movie">Indie Game: The Movie</h3>
@@ -208,8 +200,7 @@ Go behind the scenes of the independent video game industry as this documentary 
 
 * Tags: Game Development, Indie Games, Software Engineering
 * IMDb rating: 7.6 / 10 (21,724 votes)
-* [Watch on Netflix](https://www.netflix.com/title/70229918)
-
+* Watch on: [Netflix](https://www.netflix.com/title/70229918)
 ----
 
 <h3 id="inside-envoy-the-proxy-for-the-future">Inside Envoy: The Proxy for the Future</h3>
@@ -226,8 +217,7 @@ Envoy was open sourced in the fall of 2016 and quickly gained adoption. In 2017,
 * Language: en
 * Tags: Networking, Service Mesh, Open Source, Cloud Native
 * YouTube likes: 572
-* [Watch on YouTube](https://www.youtube.com/watch?v=uaksVVHDhYU)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=uaksVVHDhYU)
 ----
 
 <h3 id="intellij-idea-the-documentary">IntelliJ IDEA: The Documentary</h3>
@@ -247,8 +237,7 @@ Director: Jaś ...
 * Language: en
 * Tags: Developer Tools, IDE, JetBrains, History
 * YouTube likes: 1,512
-* [Watch on YouTube](https://www.youtube.com/watch?v=Kourq_Lz03U)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=Kourq_Lz03U)
 ----
 
 <h3 id="internet-relay-chat-irc">Internet Relay Chat (IRC)</h3>
@@ -280,8 +269,7 @@ References and sources: https://docs.google.com/document/d/e/2PACX-1vQjGmdjmESDJ
 * Language: en
 * Tags: Networking, Chat, Open Source, History
 * YouTube likes: 15,204
-* [Watch on YouTube](https://www.youtube.com/watch?v=6UbKenFipjo)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=6UbKenFipjo)
 ----
 
 <h3 id="kubernetes-the-documentary-part-1">Kubernetes: The Documentary [PART 1]</h3>
@@ -300,8 +288,7 @@ Most engineers know about “The Container Orchestrator Wars’’ ...
 * Language: en
 * Tags: Cloud Native, Orchestration, Open Source, History
 * YouTube likes: 12,674
-* [Watch on YouTube](https://www.youtube.com/watch?v=BE77h7dmoQU)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=BE77h7dmoQU)
 ----
 
 <h3 id="kubernetes-the-documentary-part-2">Kubernetes: The Documentary [PART 2]</h3>
@@ -320,8 +307,7 @@ Most engineers know about “The Container Orchestrator Wars’’ ...
 * Language: en
 * Tags: Cloud Native, Orchestration, Open Source, History
 * YouTube likes: 5,949
-* [Watch on YouTube](https://www.youtube.com/watch?v=318elIq37PE)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=318elIq37PE)
 ----
 
 <h3 id="laravel-origins-a-php-documentary">Laravel Origins: A PHP Documentary</h3>
@@ -339,8 +325,7 @@ Laravel Origins was filmed in late 2021, produced by OfferZen and directed by De
 * Language: en
 * Tags: Web Frameworks, PHP, Open Source, History
 * YouTube likes: 6,778
-* [Watch on YouTube](https://www.youtube.com/watch?v=127ng7botO4)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=127ng7botO4)
 ----
 
 <h3 id="lo-and-behold-reveries-of-the-connected-world">Lo and Behold: Reveries of the Connected World</h3>
@@ -354,8 +339,7 @@ Directed by Werner Herzog, this documentary explores the history, impact, and po
 * Tags: Internet, History, Society
 * IMDb rating: 7.0 / 10 (13,862 votes)
 * YouTube likes: 5,700
-* [Watch on YouTube](https://www.youtube.com/watch?v=q3g3hqNJqpQ)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=q3g3hqNJqpQ)
 ----
 
 <h3 id="node-js-the-documentary">Node.js: The Documentary</h3>
@@ -372,8 +356,7 @@ Join us as we delve into the origins of Node.js, meet some of its earliest contr
 * Language: en
 * Tags: JavaScript, Backend, Open Source, History
 * YouTube likes: 23,868
-* [Watch on YouTube](https://www.youtube.com/watch?v=LB8KwiiUGy0)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=LB8KwiiUGy0)
 ----
 
 <h3 id="prometheus-the-documentary">Prometheus: The Documentary</h3>
@@ -387,8 +370,7 @@ Join us as we explore the story of Prometheus, from inception to adoption as tol
 * Language: en
 * Tags: Observability, Monitoring, Open Source, Cloud Native, History
 * YouTube likes: 3,547
-* [Watch on YouTube](https://www.youtube.com/watch?v=rT4fJNbfe14)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=rT4fJNbfe14)
 ----
 
 <h3 id="python-the-documentary">Python: The Documentary</h3>
@@ -405,8 +387,7 @@ Thanks to our sponsors ...
 * Language: en
 * Tags: Programming Languages, Open Source, History
 * YouTube likes: 33,461
-* [Watch on YouTube](https://www.youtube.com/watch?v=GfH4QL4VqJ0)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=GfH4QL4VqJ0)
 ----
 
 <h3 id="react-js-the-documentary">React.js: The Documentary</h3>
@@ -420,8 +401,7 @@ But what if we told you that React’s first brush with the public sphere was an
 * Language: en
 * Tags: Frontend, JavaScript, Meta, Open Source, History
 * YouTube likes: 40,560
-* [Watch on YouTube](https://www.youtube.com/watch?v=8pDqJVdNa44)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=8pDqJVdNa44)
 ----
 
 <h3 id="revolution-os">Revolution OS</h3>
@@ -439,8 +419,7 @@ While Microsoft may be the biggest software company in the world, not every comp
 * Tags: GNU/Linux, Open Source, History
 * IMDb rating: 7.2 / 10 (2,708 votes)
 * YouTube likes: 2,191
-* [Watch on YouTube](https://www.youtube.com/watch?v=k0RYQVkQmWU)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=k0RYQVkQmWU)
 ----
 
 <h3 id="ruby-on-rails-the-documentary">Ruby on Rails: The Documentary</h3>
@@ -455,8 +434,7 @@ Get the whole spill by the people who had a front-row seat to the creation and d
 * Language: en
 * Tags: Web Frameworks, Ruby, Open Source, History
 * YouTube likes: 9,836
-* [Watch on YouTube](https://www.youtube.com/watch?v=HDKUEXBF3B4)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=HDKUEXBF3B4)
 ----
 
 <h3 id="silicon-cowboys">Silicon Cowboys</h3>
@@ -467,8 +445,7 @@ Get the whole spill by the people who had a front-row seat to the creation and d
 
 * Tags: Hardware, History, Personal Computing
 * IMDb rating: 6.9 / 10 (2,233 votes)
-* [Watch on Netflix](https://www.netflix.com/title/80104318)
-
+* Watch on: [Netflix](https://www.netflix.com/title/80104318)
 ----
 
 <h3 id="svelte-origins-a-javascript-documentary">Svelte Origins: A JavaScript Documentary</h3>
@@ -487,8 +464,7 @@ Svelte Origins ...
 * Language: en
 * Tags: Frontend, JavaScript, Open Source, History
 * YouTube likes: 6,992
-* [Watch on YouTube](https://www.youtube.com/watch?v=kMlkCYL9qo0)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=kMlkCYL9qo0)
 ----
 
 <h3 id="terms-and-conditions-may-apply">Terms and Conditions May Apply</h3>
@@ -502,8 +478,7 @@ A documentary that exposes what corporations and governments learn about people 
 * Tags: Privacy, Surveillance, Internet
 * IMDb rating: 7.3 / 10 (6,643 votes)
 * YouTube likes: 592
-* [Watch on YouTube](https://www.youtube.com/watch?v=hRJEYmodC08)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=hRJEYmodC08)
 ----
 
 <h3 id="the-cleaners">The Cleaners</h3>
@@ -514,8 +489,7 @@ This documentary reveals the hidden world of content moderation on social media 
 
 * Tags: Content Moderation, Social Media, Ethics, Society
 * IMDb rating: 7.1 / 10 (1,929 votes)
-* [Watch on Bundeszentrale für politische Bildung](https://www.bpb.de/mediathek/video/273199/the-cleaners/)
-
+* Watch on: [Bundeszentrale für politische Bildung](https://www.bpb.de/mediathek/video/273199/the-cleaners/)
 ----
 
 <h3 id="the-great-hack">The Great Hack</h3>
@@ -527,8 +501,7 @@ Explore how a data company named Cambridge Analytica came to symbolize the dark 
 * Language: en, de
 * Tags: Privacy, Social Media, Politics, Data Analytics
 * IMDb rating: 7.0 / 10 (25,799 votes)
-* [Watch on Netflix](https://www.netflix.com/title/80117542)
-
+* Watch on: [Netflix](https://www.netflix.com/title/80117542)
 ----
 
 <h3 id="the-internets-own-boy-the-story-of-aaron-swartz">The Internet&#39;s Own Boy: The Story of Aaron Swartz</h3>
@@ -545,8 +518,7 @@ This movie is made available under the Creative Commons license: ...
 * Tags: Hacktivism, Open Internet, Activism, History
 * IMDb rating: 8.0 / 10 (18,551 votes)
 * YouTube likes: 36,687
-* [Watch on YouTube](https://www.youtube.com/watch?v=9vz06QO3UkQ)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=9vz06QO3UkQ)
 ----
 
 <h3 id="typescript-origins-the-documentary">TypeScript Origins: The Documentary</h3>
@@ -569,8 +541,7 @@ Sponsored by
 * Language: en
 * Tags: Programming Languages, JavaScript, Microsoft, History
 * YouTube likes: 9,556
-* [Watch on YouTube](https://www.youtube.com/watch?v=U6s2pdxebSo)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=U6s2pdxebSo)
 ----
 
 <h3 id="vite-the-documentary">VITE: The Documentary</h3>
@@ -587,8 +558,7 @@ Featuring many prominent developers in the JavaCript ecosystem, this documentary
 * Language: en
 * Tags: Frontend, Build Tools, JavaScript, Open Source
 * YouTube likes: 5,906
-* [Watch on YouTube](https://www.youtube.com/watch?v=bmWQqAKLgT4)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=bmWQqAKLgT4)
 ----
 
 <h3 id="vue-js-the-documentary">Vue.js: The Documentary</h3>
@@ -607,8 +577,7 @@ Honeypot is a developer-focused job platform, on a mission to get every develope
 * Language: en
 * Tags: Frontend, JavaScript, Open Source, History
 * YouTube likes: 52,870
-* [Watch on YouTube](https://www.youtube.com/watch?v=OrxmtDw4pVI)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=OrxmtDw4pVI)
 ----
 
 <h3 id="we-are-legion-the-story-of-the-hacktivists">We Are Legion: The Story of the Hacktivists</h3>
@@ -622,8 +591,7 @@ This documentary takes a deep dive into the world of Anonymous, a loosely organi
 * Tags: Anonymous, Hacktivism, Security, History
 * IMDb rating: 7.2 / 10 (10,528 votes)
 * YouTube likes: 1,048
-* [Watch on YouTube](https://www.youtube.com/watch?v=4D1WJsdu6W8)
-
+* Watch on: [YouTube](https://www.youtube.com/watch?v=4D1WJsdu6W8)
 ----
 
 

--- a/app/cmd/collectMovieData.go
+++ b/app/cmd/collectMovieData.go
@@ -111,21 +111,23 @@ func cmdCollectMovieData(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("unmarshal %s: %w", absJsonFilePath, err)
 		}
 		entries = append(entries, entry{path: absJsonFilePath, info: info})
-		// YouTube enrichment runs only on YouTube entries. Other
-		// platforms (Netflix, Amazon Prime Video, bpb, …) do not have
-		// a YouTube video ID by construction.
-		if info.Platform != platform.YouTube {
+		// YouTube enrichment runs only on entries that list a youtube
+		// link. Multi-platform entries that include youtube go through
+		// the same path as YouTube-only ones — the other links are
+		// just additional metadata.
+		ytURL := info.Links[platform.YouTube]
+		if ytURL == "" {
 			continue
 		}
-		// VideoID is not persisted in JSON; derive it from Link on
-		// load. The parse-failure warning fires here, where the
-		// failure actually matters (we are about to ask the API for
-		// it).
-		if id, ok := youtube.ParseVideoID(info.Link); ok {
+		// VideoID is not persisted in JSON; derive it from the
+		// YouTube link on load. The parse-failure warning fires here,
+		// where the failure actually matters (we are about to ask the
+		// API for it).
+		if id, ok := youtube.ParseVideoID(ytURL); ok {
 			info.VideoID = id
 			ids = append(ids, id)
 		} else {
-			log.Printf("WARNING: could not parse YouTube video ID from %q in %s", info.Link, absJsonFilePath)
+			log.Printf("WARNING: could not parse YouTube video ID from %q in %s", ytURL, absJsonFilePath)
 		}
 	}
 
@@ -158,10 +160,11 @@ func cmdCollectMovieData(cmd *cobra.Command, args []string) error {
 		info := e.info
 
 		// Mirror the gate from the ID-collection loop above: only
-		// YouTube entries go through the YouTube enrichment branch
-		// at all. Other platforms keep their existing cached values
-		// (which the IMDb pass below may still update independently).
-		if info.Platform != platform.YouTube {
+		// entries with a youtube link go through the YouTube
+		// enrichment branch. Other platforms keep their existing
+		// cached values (which the IMDb pass below may still update
+		// independently).
+		if info.Links[platform.YouTube] == "" {
 			continue
 		}
 

--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -113,8 +113,7 @@ func cmdConvertYamlToJson(cmd *cobra.Command, args []string) error {
 
 		// Generated fields
 		movieInfo.Slug = slug.Make(movieInfo.Name)
-		resolvePlatform(movieInfo, absYamlFilePath)
-		resolveLocalizedPlatforms(movieInfo, absYamlFilePath)
+		validateLinks(movieInfo.Links, absYamlFilePath)
 		validateLocalized(movieInfo, absYamlFilePath)
 
 		log.Printf("Write %s to disk ...", absJsonFilePath)
@@ -142,7 +141,7 @@ func cmdConvertYamlToJson(cmd *cobra.Command, args []string) error {
 // in collectMovieData; here we only handle the YAML-vs-cached merge.
 func mergeMovieInformation(source, target *MovieInformation) *MovieInformation {
 	target.Name = source.Name
-	target.Link = source.Link
+	target.Links = source.Links
 	if len(source.Language) > 0 {
 		target.Language = source.Language
 	}
@@ -164,9 +163,6 @@ func mergeMovieInformation(source, target *MovieInformation) *MovieInformation {
 	if len(source.IMDbID) > 0 {
 		target.IMDbID = source.IMDbID
 	}
-	if len(source.Platform) > 0 {
-		target.Platform = source.Platform
-	}
 	if len(source.YouTubeTrailerForThumbnail) > 0 {
 		target.YouTubeTrailerForThumbnail = source.YouTubeTrailerForThumbnail
 	}
@@ -182,7 +178,8 @@ func mergeMovieInformation(source, target *MovieInformation) *MovieInformation {
 // entry with no override fields set at all (in which case the key
 // adds nothing to the file). Each problem is logged as a warning so
 // the maintainer notices, but the conversion proceeds — the data
-// shape is still valid YAML.
+// shape is still valid YAML. Per-localized links are also fed to
+// validateLinks for URL/slug consistency checks.
 //
 // fileLabel is the human-friendly file path for the warning text.
 func validateLocalized(info *MovieInformation, fileLabel string) {
@@ -191,10 +188,11 @@ func validateLocalized(info *MovieInformation, fileLabel string) {
 			log.Printf("WARNING: %s: localized language key %q is not a 2-letter lowercase code; expected ISO 639-1",
 				fileLabel, code)
 		}
-		if v.Title == "" && v.Link == "" && v.Description == "" {
-			log.Printf("WARNING: %s: localized.%s has no overrides set; remove the key or fill in at least one of title/link/description",
+		if v.Title == "" && v.Description == "" && len(v.Links) == 0 {
+			log.Printf("WARNING: %s: localized.%s has no overrides set; remove the key or fill in at least one of title/description/links",
 				fileLabel, code)
 		}
+		validateLinks(v.Links, fmt.Sprintf("%s localized.%s", fileLabel, code))
 	}
 }
 
@@ -208,52 +206,27 @@ func isISO639_1Like(s string) bool {
 	return s[0] >= 'a' && s[0] <= 'z' && s[1] >= 'a' && s[1] <= 'z'
 }
 
-// resolvePlatformValue centralises the four-warning-branch decision
-// so both the top-level entry and per-localized entries reuse it
-// without duplication. Returns the resolved platform value (which
-// may be empty) and emits warnings as a side effect.
+// validateLinks logs a warning for each known-slug entry whose URL
+// does not look like that slug (likely typo). Unknown slugs are
+// passed through silently — a maintainer may pre-declare a platform
+// before its detector lands. The function does not modify links;
+// the YAML value is always kept.
 //
-// The YAML value always wins — when currentPlatform is non-empty it
-// flows through unchanged.
-func resolvePlatformValue(currentPlatform, link, label string) string {
-	detected, detectedOK := platform.Detect(link)
-	switch {
-	case currentPlatform == "" && detectedOK:
-		return detected
-	case currentPlatform == "" && !detectedOK:
-		log.Printf("WARNING: %s has no platform in YAML and link %q matches no known platform; leaving empty",
-			label, link)
-		return ""
-	case currentPlatform != "" && detectedOK && currentPlatform != detected:
-		log.Printf("WARNING: %s YAML platform %q disagrees with link-detected platform %q; keeping YAML value",
-			label, currentPlatform, detected)
-		return currentPlatform
-	case currentPlatform != "" && !detectedOK:
-		log.Printf("WARNING: %s YAML platform %q set but link %q matches no known platform; keeping YAML value",
-			label, currentPlatform, link)
-		return currentPlatform
-	}
-	// YAML value matches the detected value, or both are empty —
-	// nothing to report.
-	return currentPlatform
-}
-
-// resolvePlatform fills in info.Platform from the top-level link
-// when YAML did not set it, surfacing the four warning paths from
-// resolvePlatformValue with a fileLabel-only label.
-func resolvePlatform(info *MovieInformation, fileLabel string) {
-	info.Platform = resolvePlatformValue(info.Platform, info.Link, fileLabel)
-}
-
-// resolveLocalizedPlatforms fills in Platform on each localized
-// entry whose link is set. Description-only or title-only overrides
-// have no link to detect against and are left untouched.
-func resolveLocalizedPlatforms(info *MovieInformation, fileLabel string) {
-	for code, v := range info.Localized {
-		if v.Link == "" {
+// label is the human-friendly file path (plus optional context like
+// "localized.de") used only in the warning text.
+func validateLinks(links map[string]string, label string) {
+	for slug, url := range links {
+		if !platform.IsKnown(slug) {
 			continue
 		}
-		v.Platform = resolvePlatformValue(v.Platform, v.Link, fmt.Sprintf("%s localized.%s", fileLabel, code))
-		info.Localized[code] = v
+		detected, ok := platform.Detect(url)
+		switch {
+		case !ok:
+			log.Printf("WARNING: %s links.%s URL %q matches no known platform; the slug says it should be %q",
+				label, slug, url, slug)
+		case detected != slug:
+			log.Printf("WARNING: %s links.%s URL %q looks like %q, not %q; keeping the slug as written",
+				label, slug, url, detected, slug)
+		}
 	}
 }

--- a/app/cmd/convertYamlToJson_test.go
+++ b/app/cmd/convertYamlToJson_test.go
@@ -7,14 +7,17 @@ import (
 	"testing"
 )
 
-// mergeMovieInformation has three override-only fields (Language,
-// Subtitles, Description) whose YAML > API precedence is easy to
-// break by accident on schema changes. These tests pin the contract.
+// stubLinks is a reusable test fixture so each precedence test does
+// not have to re-spell the map literal — and so swapping the link
+// schema again later is a single-line change here.
+func stubLinks() map[string]string {
+	return map[string]string{"youtube": "https://www.youtube.com/watch?v=abc123"}
+}
 
 func TestMergeMovieInformation_DescriptionPrecedence(t *testing.T) {
 	t.Run("YAML description overrides target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l", Description: "from-yaml"}
-		json := &MovieInformation{Name: "stale", Link: "stale", Description: "from-api"}
+		yaml := &MovieInformation{Name: "n", Links: stubLinks(), Description: "from-yaml"}
+		json := &MovieInformation{Name: "stale", Links: stubLinks(), Description: "from-api"}
 
 		got := mergeMovieInformation(yaml, json)
 		if got.Description != "from-yaml" {
@@ -23,8 +26,8 @@ func TestMergeMovieInformation_DescriptionPrecedence(t *testing.T) {
 	})
 
 	t.Run("empty YAML description preserves target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l"} // Description empty
-		json := &MovieInformation{Name: "stale", Link: "stale", Description: "from-api"}
+		yaml := &MovieInformation{Name: "n", Links: stubLinks()} // Description empty
+		json := &MovieInformation{Name: "stale", Links: stubLinks(), Description: "from-api"}
 
 		got := mergeMovieInformation(yaml, json)
 		if got.Description != "from-api" {
@@ -35,8 +38,8 @@ func TestMergeMovieInformation_DescriptionPrecedence(t *testing.T) {
 
 func TestMergeMovieInformation_TitlePrecedence(t *testing.T) {
 	t.Run("YAML title overrides target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l", Title: "from-yaml"}
-		json := &MovieInformation{Name: "stale", Link: "stale", Title: "from-api"}
+		yaml := &MovieInformation{Name: "n", Links: stubLinks(), Title: "from-yaml"}
+		json := &MovieInformation{Name: "stale", Links: stubLinks(), Title: "from-api"}
 
 		got := mergeMovieInformation(yaml, json)
 		if got.Title != "from-yaml" {
@@ -45,8 +48,8 @@ func TestMergeMovieInformation_TitlePrecedence(t *testing.T) {
 	})
 
 	t.Run("empty YAML title preserves target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l"}
-		json := &MovieInformation{Name: "stale", Link: "stale", Title: "from-api"}
+		yaml := &MovieInformation{Name: "n", Links: stubLinks()}
+		json := &MovieInformation{Name: "stale", Links: stubLinks(), Title: "from-api"}
 
 		got := mergeMovieInformation(yaml, json)
 		if got.Title != "from-api" {
@@ -57,8 +60,8 @@ func TestMergeMovieInformation_TitlePrecedence(t *testing.T) {
 
 func TestMergeMovieInformation_DurationPrecedence(t *testing.T) {
 	t.Run("YAML duration overrides target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l", Duration: "PT1H54M"}
-		json := &MovieInformation{Name: "stale", Link: "stale", Duration: "PT2H"}
+		yaml := &MovieInformation{Name: "n", Links: stubLinks(), Duration: "PT1H54M"}
+		json := &MovieInformation{Name: "stale", Links: stubLinks(), Duration: "PT2H"}
 
 		got := mergeMovieInformation(yaml, json)
 		if got.Duration != "PT1H54M" {
@@ -67,8 +70,8 @@ func TestMergeMovieInformation_DurationPrecedence(t *testing.T) {
 	})
 
 	t.Run("empty YAML duration preserves target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l"}
-		json := &MovieInformation{Name: "stale", Link: "stale", Duration: "PT2H"}
+		yaml := &MovieInformation{Name: "n", Links: stubLinks()}
+		json := &MovieInformation{Name: "stale", Links: stubLinks(), Duration: "PT2H"}
 
 		got := mergeMovieInformation(yaml, json)
 		if got.Duration != "PT2H" {
@@ -79,8 +82,8 @@ func TestMergeMovieInformation_DurationPrecedence(t *testing.T) {
 
 func TestMergeMovieInformation_PublishedAtPrecedence(t *testing.T) {
 	t.Run("YAML publishedAt overrides target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l", PublishedAt: "2019-07-24T00:00:00Z"}
-		json := &MovieInformation{Name: "stale", Link: "stale", PublishedAt: "2019-01-01T00:00:00Z"}
+		yaml := &MovieInformation{Name: "n", Links: stubLinks(), PublishedAt: "2019-07-24T00:00:00Z"}
+		json := &MovieInformation{Name: "stale", Links: stubLinks(), PublishedAt: "2019-01-01T00:00:00Z"}
 
 		got := mergeMovieInformation(yaml, json)
 		if got.PublishedAt != "2019-07-24T00:00:00Z" {
@@ -89,8 +92,8 @@ func TestMergeMovieInformation_PublishedAtPrecedence(t *testing.T) {
 	})
 
 	t.Run("empty YAML publishedAt preserves target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l"}
-		json := &MovieInformation{Name: "stale", Link: "stale", PublishedAt: "2019-01-01T00:00:00Z"}
+		yaml := &MovieInformation{Name: "n", Links: stubLinks()}
+		json := &MovieInformation{Name: "stale", Links: stubLinks(), PublishedAt: "2019-01-01T00:00:00Z"}
 
 		got := mergeMovieInformation(yaml, json)
 		if got.PublishedAt != "2019-01-01T00:00:00Z" {
@@ -101,8 +104,8 @@ func TestMergeMovieInformation_PublishedAtPrecedence(t *testing.T) {
 
 func TestMergeMovieInformation_LanguagePrecedence(t *testing.T) {
 	t.Run("YAML language overrides target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l", Language: []string{"de"}}
-		json := &MovieInformation{Name: "stale", Link: "stale", Language: []string{"en"}}
+		yaml := &MovieInformation{Name: "n", Links: stubLinks(), Language: []string{"de"}}
+		json := &MovieInformation{Name: "stale", Links: stubLinks(), Language: []string{"en"}}
 
 		got := mergeMovieInformation(yaml, json)
 		if len(got.Language) != 1 || got.Language[0] != "de" {
@@ -111,8 +114,8 @@ func TestMergeMovieInformation_LanguagePrecedence(t *testing.T) {
 	})
 
 	t.Run("empty YAML language preserves target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l"} // Language empty
-		json := &MovieInformation{Name: "stale", Link: "stale", Language: []string{"en"}}
+		yaml := &MovieInformation{Name: "n", Links: stubLinks()} // Language empty
+		json := &MovieInformation{Name: "stale", Links: stubLinks(), Language: []string{"en"}}
 
 		got := mergeMovieInformation(yaml, json)
 		if len(got.Language) != 1 || got.Language[0] != "en" {
@@ -123,8 +126,8 @@ func TestMergeMovieInformation_LanguagePrecedence(t *testing.T) {
 
 func TestMergeMovieInformation_SubtitlesPrecedence(t *testing.T) {
 	t.Run("YAML subtitles override target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l", Subtitles: []string{"de"}}
-		json := &MovieInformation{Name: "stale", Link: "stale", Subtitles: []string{"en", "fr"}}
+		yaml := &MovieInformation{Name: "n", Links: stubLinks(), Subtitles: []string{"de"}}
+		json := &MovieInformation{Name: "stale", Links: stubLinks(), Subtitles: []string{"en", "fr"}}
 
 		got := mergeMovieInformation(yaml, json)
 		if len(got.Subtitles) != 1 || got.Subtitles[0] != "de" {
@@ -133,8 +136,8 @@ func TestMergeMovieInformation_SubtitlesPrecedence(t *testing.T) {
 	})
 
 	t.Run("empty YAML subtitles preserves target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l"} // Subtitles empty
-		json := &MovieInformation{Name: "stale", Link: "stale", Subtitles: []string{"en", "de"}}
+		yaml := &MovieInformation{Name: "n", Links: stubLinks()} // Subtitles empty
+		json := &MovieInformation{Name: "stale", Links: stubLinks(), Subtitles: []string{"en", "de"}}
 
 		got := mergeMovieInformation(yaml, json)
 		if len(got.Subtitles) != 2 || got.Subtitles[0] != "en" || got.Subtitles[1] != "de" {
@@ -143,60 +146,59 @@ func TestMergeMovieInformation_SubtitlesPrecedence(t *testing.T) {
 	})
 }
 
-func TestResolvePlatform(t *testing.T) {
+func TestMergeMovieInformation_LinksReplace(t *testing.T) {
+	t.Run("YAML links replace target wholesale", func(t *testing.T) {
+		yaml := &MovieInformation{Name: "n", Links: map[string]string{"netflix": "yaml-nf"}}
+		json := &MovieInformation{Name: "stale", Links: map[string]string{"youtube": "stale-yt"}}
+
+		got := mergeMovieInformation(yaml, json)
+		if len(got.Links) != 1 || got.Links["netflix"] != "yaml-nf" {
+			t.Fatalf("Links = %v; want exactly the YAML map", got.Links)
+		}
+	})
+}
+
+func TestValidateLinks(t *testing.T) {
 	cases := []struct {
 		name        string
-		yamlValue   string
-		link        string
-		wantValue   string
+		links       map[string]string
 		wantWarnSub string // empty = expect no warning
 	}{
 		{
-			name:      "autodetect from YouTube link when YAML omits platform",
-			link:      "https://www.youtube.com/watch?v=abc123",
-			wantValue: "youtube",
+			name: "matching slug + URL emits no warning",
+			links: map[string]string{
+				"youtube": "https://www.youtube.com/watch?v=abc",
+				"netflix": "https://www.netflix.com/title/12345",
+			},
 		},
 		{
-			name:      "explicit YAML matches detector → no warning",
-			yamlValue: "youtube",
-			link:      "https://youtu.be/abc123",
-			wantValue: "youtube",
+			name:  "empty map emits no warning",
+			links: map[string]string{},
 		},
 		{
-			name:        "YAML disagrees with link → warn, keep YAML",
-			yamlValue:   "netflix",
-			link:        "https://www.youtube.com/watch?v=abc123",
-			wantValue:   "netflix",
-			wantWarnSub: "disagrees with link-detected platform",
+			name:  "unknown slug passes through silently",
+			links: map[string]string{"vimeo": "https://vimeo.com/12345"},
 		},
 		{
-			name:        "YAML set, link unrecognised → warn, keep YAML",
-			yamlValue:   "netflix",
-			link:        "https://example.com/foo",
-			wantValue:   "netflix",
-			wantWarnSub: "matches no known platform; keeping YAML value",
+			name:        "known slug with mismatched URL warns",
+			links:       map[string]string{"netflix": "https://www.youtube.com/watch?v=abc"},
+			wantWarnSub: "looks like \"youtube\", not \"netflix\"",
 		},
 		{
-			name:        "neither YAML nor detector → warn, leave empty",
-			link:        "https://example.com/foo",
-			wantValue:   "",
-			wantWarnSub: "leaving empty",
+			name:        "known slug with unrecognised URL warns",
+			links:       map[string]string{"netflix": "https://example.com/foo"},
+			wantWarnSub: "matches no known platform",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			info := &MovieInformation{Link: tc.link, Platform: tc.yamlValue}
-
 			var buf bytes.Buffer
 			prev := log.Writer()
 			log.SetOutput(&buf)
 			defer log.SetOutput(prev)
 
-			resolvePlatform(info, "test.yml")
+			validateLinks(tc.links, "test.yml")
 
-			if info.Platform != tc.wantValue {
-				t.Errorf("Platform = %q; want %q", info.Platform, tc.wantValue)
-			}
 			out := buf.String()
 			switch {
 			case tc.wantWarnSub == "" && strings.Contains(out, "WARNING"):
@@ -211,15 +213,15 @@ func TestResolvePlatform(t *testing.T) {
 func TestMergeMovieInformation_LocalizedPrecedence(t *testing.T) {
 	t.Run("YAML localized map overrides target", func(t *testing.T) {
 		yaml := &MovieInformation{
-			Name: "n", Link: "l",
+			Name: "n", Links: stubLinks(),
 			Localized: map[string]LocalizedVersion{
-				"de": {Title: "from-yaml", Link: "yaml-link"},
+				"de": {Title: "from-yaml", Links: map[string]string{"amazon_prime_video": "yaml-link"}},
 			},
 		}
 		json := &MovieInformation{
-			Name: "stale", Link: "stale",
+			Name: "stale", Links: stubLinks(),
 			Localized: map[string]LocalizedVersion{
-				"de": {Title: "stale-title", Link: "stale-link"},
+				"de": {Title: "stale-title", Links: map[string]string{"amazon_prime_video": "stale-link"}},
 				"es": {Title: "should-be-dropped"},
 			},
 		}
@@ -228,8 +230,8 @@ func TestMergeMovieInformation_LocalizedPrecedence(t *testing.T) {
 		if len(got.Localized) != 1 {
 			t.Fatalf("Localized = %v; want exactly the YAML map", got.Localized)
 		}
-		if got.Localized["de"].Title != "from-yaml" || got.Localized["de"].Link != "yaml-link" {
-			t.Fatalf("Localized[de] = %+v; want from-yaml/yaml-link", got.Localized["de"])
+		if got.Localized["de"].Title != "from-yaml" || got.Localized["de"].Links["amazon_prime_video"] != "yaml-link" {
+			t.Fatalf("Localized[de] = %+v; want from-yaml + yaml-link", got.Localized["de"])
 		}
 		if _, ok := got.Localized["es"]; ok {
 			t.Errorf("YAML omitting 'es' must drop it; map currently has it")
@@ -237,9 +239,9 @@ func TestMergeMovieInformation_LocalizedPrecedence(t *testing.T) {
 	})
 
 	t.Run("empty YAML localized preserves target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l"} // Localized empty
+		yaml := &MovieInformation{Name: "n", Links: stubLinks()} // Localized empty
 		json := &MovieInformation{
-			Name: "stale", Link: "stale",
+			Name: "stale", Links: stubLinks(),
 			Localized: map[string]LocalizedVersion{
 				"de": {Title: "from-target"},
 			},
@@ -261,9 +263,9 @@ func TestValidateLocalized(t *testing.T) {
 		{
 			name: "well-formed entries do not warn",
 			localized: map[string]LocalizedVersion{
-				"de": {Title: "Pythons Geschichte", Link: "https://example.com/de"},
+				"de": {Title: "Pythons Geschichte", Links: map[string]string{"netflix": "https://www.netflix.com/title/12"}},
 				"es": {Title: "La historia de Python"},
-				"fr": {Link: "https://example.com/fr"},
+				"fr": {Links: map[string]string{"youtube": "https://www.youtube.com/watch?v=fr"}},
 				"it": {Description: "Una descrizione localizzata"},
 			},
 		},
@@ -308,82 +310,4 @@ func TestValidateLocalized(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestResolveLocalizedPlatforms(t *testing.T) {
-	t.Run("autodetects from localized link", func(t *testing.T) {
-		info := &MovieInformation{
-			Localized: map[string]LocalizedVersion{
-				"de": {Link: "https://www.amazon.de/gp/video/detail/B0FVCKCM81/"},
-			},
-		}
-		var buf bytes.Buffer
-		prev := log.Writer()
-		log.SetOutput(&buf)
-		defer log.SetOutput(prev)
-
-		resolveLocalizedPlatforms(info, "test.yml")
-
-		if got := info.Localized["de"].Platform; got != "amazon_prime_video" {
-			t.Fatalf("Localized[de].Platform = %q; want amazon_prime_video", got)
-		}
-		if strings.Contains(buf.String(), "WARNING") {
-			t.Errorf("expected no warning, got: %s", buf.String())
-		}
-	})
-
-	t.Run("description-only entry is left alone", func(t *testing.T) {
-		info := &MovieInformation{
-			Localized: map[string]LocalizedVersion{
-				"de": {Description: "Eine deutsche Beschreibung"},
-			},
-		}
-		resolveLocalizedPlatforms(info, "test.yml")
-		if got := info.Localized["de"].Platform; got != "" {
-			t.Errorf("Localized[de].Platform = %q; want empty (no link to detect from)", got)
-		}
-	})
-
-	t.Run("YAML override on localized link survives", func(t *testing.T) {
-		info := &MovieInformation{
-			Localized: map[string]LocalizedVersion{
-				"de": {Link: "https://www.amazon.de/gp/video/detail/B0/", Platform: "netflix"},
-			},
-		}
-		var buf bytes.Buffer
-		prev := log.Writer()
-		log.SetOutput(&buf)
-		defer log.SetOutput(prev)
-
-		resolveLocalizedPlatforms(info, "test.yml")
-
-		if got := info.Localized["de"].Platform; got != "netflix" {
-			t.Errorf("Localized[de].Platform = %q; want %q (YAML wins)", got, "netflix")
-		}
-		if !strings.Contains(buf.String(), "disagrees") {
-			t.Errorf("expected disagreement warning, got: %s", buf.String())
-		}
-	})
-}
-
-func TestMergeMovieInformation_PlatformPrecedence(t *testing.T) {
-	t.Run("YAML platform overrides target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l", Platform: "netflix"}
-		json := &MovieInformation{Name: "stale", Link: "stale", Platform: "youtube"}
-
-		got := mergeMovieInformation(yaml, json)
-		if got.Platform != "netflix" {
-			t.Fatalf("Platform = %q; want %q", got.Platform, "netflix")
-		}
-	})
-
-	t.Run("empty YAML platform preserves target", func(t *testing.T) {
-		yaml := &MovieInformation{Name: "n", Link: "l"}
-		json := &MovieInformation{Name: "stale", Link: "stale", Platform: "youtube"}
-
-		got := mergeMovieInformation(yaml, json)
-		if got.Platform != "youtube" {
-			t.Fatalf("Platform = %q; want %q (target preserved)", got.Platform, "youtube")
-		}
-	})
 }

--- a/app/cmd/types.go
+++ b/app/cmd/types.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -20,19 +21,18 @@ type MovieInformation struct {
 	// filenames, README anchors and image paths.
 	Slug string `yaml:"-" json:"slug"`
 
-	Link string `yaml:"link" json:"link"`
+	// Links maps platform slugs to watch URLs (e.g. "youtube" →
+	// "https://www.youtube.com/...", "netflix" → "https://www.netflix.com/...").
+	// At least one entry is required. The keys of this map double as
+	// the entry's platform list; there is no separate Platform field.
+	Links map[string]string `yaml:"links" json:"links"`
 	// VideoID is YouTube-specific and lives only as a runtime field:
 	// not persisted to JSON, not curated in YAML. collectMovieData
-	// derives it from Link on load via youtube.ParseVideoID and uses
-	// it for the videos.list API call, the response→entry join, and
-	// the thumbnail URL. Other platforms leave it empty.
+	// derives it from Links["youtube"] on load via youtube.ParseVideoID
+	// and uses it for the videos.list API call, the response→entry
+	// join, and the thumbnail URL. Empty for entries with no YouTube
+	// link.
 	VideoID string `yaml:"-" json:"-"`
-	// Platform identifies which source the link lives on (e.g.
-	// "youtube"). Optional in YAML — convertYamlToJson auto-fills it
-	// from the link via the platform package when omitted. The YAML
-	// value, when set, always wins; convertYamlToJson logs a warning
-	// when YAML and link disagree.
-	Platform string `yaml:"platform,omitempty" json:"platform"`
 
 	// Language is a list of ISO 639-1 codes (e.g. ["en"], ["en", "de"]).
 	// Curated by hand because the YouTube API does not reliably expose
@@ -44,11 +44,12 @@ type MovieInformation struct {
 	Subtitles []string `yaml:"subtitles" json:"subtitles"`
 	Tags      []string `yaml:"tags"      json:"tags"`
 	// Localized maps ISO 639-1 codes (e.g. "de", "es") to per-language
-	// overrides. The top-level Name and Link are always the English
+	// overrides. The top-level Name and Links are always the English
 	// version; entries here describe alternate-language versions of
-	// the same content (a different upload, a translated title, or
-	// both). Optional in YAML; absent for entries that only exist in
-	// one language. Map omits itself from JSON when empty.
+	// the same content. Localized.Links is per-key merged onto the
+	// top-level map at consumer time (omitted keys inherit from
+	// top-level). Optional in YAML; absent for entries that only
+	// exist in one language. Map omits itself from JSON when empty.
 	Localized map[string]LocalizedVersion `yaml:"localized,omitempty" json:"localized,omitempty"`
 
 	// API-enriched fields below this line. Some are also YAML-
@@ -103,17 +104,15 @@ type MovieInformation struct {
 // alternate version of an entry. All fields are individually
 // optional: maintainers fill in whichever differs from the top-level
 // English version (a translated title, a translated description, a
-// different upload, or any combination).
+// different upload on a different platform, or any combination).
 type LocalizedVersion struct {
 	Title       string `yaml:"title,omitempty"       json:"title,omitempty"`
-	Link        string `yaml:"link,omitempty"        json:"link,omitempty"`
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
-	// Platform is autodetected from Link by convertYamlToJson when
-	// empty, with the same precedence rules as MovieInformation.Platform:
-	// YAML wins when set; the resolver warns on disagreement. Stays
-	// empty for description-only or title-only overrides because
-	// there is no link to detect against.
-	Platform string `yaml:"platform,omitempty" json:"platform,omitempty"`
+	// Links is a per-key merge over MovieInformation.Links: only the
+	// platforms listed here override their top-level counterparts;
+	// every other top-level platform is inherited unchanged. Stored
+	// in JSON as written, not pre-merged.
+	Links map[string]string `yaml:"links,omitempty" json:"links,omitempty"`
 }
 
 // YouTubeRating holds rating-like signals YouTube exposes via
@@ -170,11 +169,32 @@ func (m *MovieInformation) SubtitlesAsList() string {
 	return strings.Join(m.Subtitles, ", ")
 }
 
-// PlatformDisplay returns the human-readable platform name for the
-// README, e.g. "YouTube" for the slug "youtube". Empty / unknown
-// slugs degrade gracefully via platform.Display.
-func (m *MovieInformation) PlatformDisplay() string {
-	return platform.Display(m.Platform)
+// HasLinks reports whether the entry has at least one watch URL.
+// Used by the README template to gate the "Watch on" line.
+func (m *MovieInformation) HasLinks() bool {
+	return len(m.Links) > 0
+}
+
+// LinksFormatted renders the entry's watch URLs as a single inline
+// list for the README, e.g. "[YouTube](url) | [Netflix](url)".
+// Sorted alphabetically by display name so order is deterministic
+// and stable across runs.
+func (m *MovieInformation) LinksFormatted() string {
+	if len(m.Links) == 0 {
+		return ""
+	}
+	slugs := make([]string, 0, len(m.Links))
+	for slug := range m.Links {
+		slugs = append(slugs, slug)
+	}
+	sort.Slice(slugs, func(i, j int) bool {
+		return platform.Display(slugs[i]) < platform.Display(slugs[j])
+	})
+	parts := make([]string, len(slugs))
+	for i, slug := range slugs {
+		parts[i] = fmt.Sprintf("[%s](%s)", platform.Display(slug), m.Links[slug])
+	}
+	return strings.Join(parts, " | ")
 }
 
 // HasYouTubeLikes reports whether the YouTube rating block is

--- a/app/cmd/types_test.go
+++ b/app/cmd/types_test.go
@@ -42,18 +42,37 @@ func TestDurationHumanReadable(t *testing.T) {
 	}
 }
 
-func TestPlatformDisplay(t *testing.T) {
-	cases := map[string]string{
-		"youtube": "YouTube",
-		"":        "",
-		"unknown": "unknown", // delegated to platform.Display, returned verbatim
-	}
-	for slug, want := range cases {
-		m := &MovieInformation{Platform: slug}
-		if got := m.PlatformDisplay(); got != want {
-			t.Errorf("PlatformDisplay(%q) = %q; want %q", slug, got, want)
+func TestLinksFormatted(t *testing.T) {
+	t.Run("empty links yields empty string", func(t *testing.T) {
+		m := &MovieInformation{}
+		if got := m.LinksFormatted(); got != "" {
+			t.Errorf("LinksFormatted on empty = %q; want empty", got)
 		}
-	}
+		if m.HasLinks() {
+			t.Error("HasLinks on empty should be false")
+		}
+	})
+
+	t.Run("single platform renders without pipe", func(t *testing.T) {
+		m := &MovieInformation{Links: map[string]string{"youtube": "https://youtu.be/abc"}}
+		want := "[YouTube](https://youtu.be/abc)"
+		if got := m.LinksFormatted(); got != want {
+			t.Errorf("LinksFormatted = %q; want %q", got, want)
+		}
+	})
+
+	t.Run("multiple platforms sort alphabetically by display name", func(t *testing.T) {
+		m := &MovieInformation{Links: map[string]string{
+			"youtube":            "https://youtu.be/abc",
+			"netflix":            "https://www.netflix.com/title/1",
+			"amazon_prime_video": "https://www.amazon.de/gp/video/detail/B0",
+		}}
+		// Display names: "Amazon Prime Video", "Netflix", "YouTube" — already alphabetical.
+		want := "[Amazon Prime Video](https://www.amazon.de/gp/video/detail/B0) | [Netflix](https://www.netflix.com/title/1) | [YouTube](https://youtu.be/abc)"
+		if got := m.LinksFormatted(); got != want {
+			t.Errorf("LinksFormatted = %q; want %q", got, want)
+		}
+	})
 }
 
 func TestTagsAsList(t *testing.T) {

--- a/app/platform/platform.go
+++ b/app/platform/platform.go
@@ -88,3 +88,13 @@ func Display(slug string) string {
 	}
 	return slug
 }
+
+// IsKnown reports whether slug is one of the platforms the tooling
+// has a detector and display name for. Unknown slugs are accepted
+// into the schema (callers may want to pre-declare a platform
+// before its detector lands), but URL/slug consistency is only
+// checked for known ones.
+func IsKnown(slug string) bool {
+	_, ok := displayNames[slug]
+	return ok
+}

--- a/app/platform/platform_test.go
+++ b/app/platform/platform_test.go
@@ -44,6 +44,22 @@ func TestDetect(t *testing.T) {
 	}
 }
 
+func TestIsKnown(t *testing.T) {
+	cases := map[string]bool{
+		YouTube:          true,
+		Netflix:          true,
+		AmazonPrimeVideo: true,
+		BPB:              true,
+		"vimeo":          false,
+		"":               false,
+	}
+	for slug, want := range cases {
+		if got := IsKnown(slug); got != want {
+			t.Errorf("IsKnown(%q) = %v; want %v", slug, got, want)
+		}
+	}
+}
+
 func TestDisplay(t *testing.T) {
 	cases := map[string]string{
 		YouTube:          "YouTube",

--- a/assets/README.template
+++ b/assets/README.template
@@ -29,7 +29,8 @@ A curated list of movies, documentaries and other related material to watch rela
 {{ end -}}
 {{ if $movie.HasYouTubeLikes }}* YouTube likes: {{ $movie.YouTubeLikeCountFormatted }}
 {{ end -}}
-* [Watch on {{ $movie.PlatformDisplay }}]({{ $movie.Link }})
+{{ if $movie.HasLinks }}* Watch on: {{ $movie.LinksFormatted }}
+{{ end -}}
 
 ----
 {{ end }}

--- a/generated/angular-the-documentary.json
+++ b/generated/angular-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "Angular: The Documentary",
  "slug": "angular-the-documentary",
- "link": "https://www.youtube.com/watch?v=cRC9DlH45lA",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=cRC9DlH45lA"
+ },
  "language": [
   "en"
  ],

--- a/generated/clojure-the-documentary.json
+++ b/generated/clojure-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "Clojure: The Documentary",
  "slug": "clojure-the-documentary",
- "link": "https://www.youtube.com/watch?v=Y24vK_QDLFg",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=Y24vK_QDLFg"
+ },
  "language": [
   "en"
  ],

--- a/generated/code-debugging-the-gender-gap.json
+++ b/generated/code-debugging-the-gender-gap.json
@@ -1,8 +1,9 @@
 {
  "name": "CODE: Debugging the Gender Gap",
  "slug": "code-debugging-the-gender-gap",
- "link": "https://www.youtube.com/watch?v=rQKRw6tWsb8",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=rQKRw6tWsb8"
+ },
  "language": [
   "en"
  ],

--- a/generated/ebpf-unlocking-the-kernel.json
+++ b/generated/ebpf-unlocking-the-kernel.json
@@ -1,8 +1,9 @@
 {
  "name": "eBPF: Unlocking the Kernel",
  "slug": "ebpf-unlocking-the-kernel",
- "link": "https://www.youtube.com/watch?v=Wb_vD3XZYOA",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=Wb_vD3XZYOA"
+ },
  "language": [
   "en"
  ],

--- a/generated/elixir-the-documentary.json
+++ b/generated/elixir-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "Elixir: The Documentary",
  "slug": "elixir-the-documentary",
- "link": "https://www.youtube.com/watch?v=lxYFOM3UJzo",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=lxYFOM3UJzo"
+ },
  "language": [
   "en"
  ],

--- a/generated/ember-js-the-documentary.json
+++ b/generated/ember-js-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "Ember.js: The Documentary",
  "slug": "ember-js-the-documentary",
- "link": "https://www.youtube.com/watch?v=Cvz-9ccflKQ",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=Cvz-9ccflKQ"
+ },
  "language": [
   "en"
  ],

--- a/generated/graphql-the-documentary.json
+++ b/generated/graphql-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "GraphQL: The Documentary",
  "slug": "graphql-the-documentary",
- "link": "https://www.youtube.com/watch?v=783ccP__No8",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=783ccP__No8"
+ },
  "language": [
   "en"
  ],

--- a/generated/half-life-25th-anniversary-documentary.json
+++ b/generated/half-life-25th-anniversary-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "Half-Life: 25th Anniversary Documentary",
  "slug": "half-life-25th-anniversary-documentary",
- "link": "https://www.youtube.com/watch?v=TbZ3HzvFEto",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=TbZ3HzvFEto"
+ },
  "language": [
   "en"
  ],

--- a/generated/indie-game-the-movie.json
+++ b/generated/indie-game-the-movie.json
@@ -1,8 +1,9 @@
 {
  "name": "Indie Game: The Movie",
  "slug": "indie-game-the-movie",
- "link": "https://www.netflix.com/title/70229918",
- "platform": "netflix",
+ "links": {
+  "netflix": "https://www.netflix.com/title/70229918"
+ },
  "language": null,
  "subtitles": null,
  "tags": [

--- a/generated/inside-envoy.json
+++ b/generated/inside-envoy.json
@@ -1,8 +1,9 @@
 {
  "name": "Inside Envoy: The Proxy for the Future",
  "slug": "inside-envoy-the-proxy-for-the-future",
- "link": "https://www.youtube.com/watch?v=uaksVVHDhYU",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=uaksVVHDhYU"
+ },
  "language": [
   "en"
  ],

--- a/generated/intellij-idea-the-documentary.json
+++ b/generated/intellij-idea-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "IntelliJ IDEA: The Documentary",
  "slug": "intellij-idea-the-documentary",
- "link": "https://www.youtube.com/watch?v=Kourq_Lz03U",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=Kourq_Lz03U"
+ },
  "language": [
   "en"
  ],

--- a/generated/internet-relay-chat-irc.json
+++ b/generated/internet-relay-chat-irc.json
@@ -1,8 +1,9 @@
 {
  "name": "Internet Relay Chat (IRC)",
  "slug": "internet-relay-chat-irc",
- "link": "https://www.youtube.com/watch?v=6UbKenFipjo",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=6UbKenFipjo"
+ },
  "language": [
   "en"
  ],

--- a/generated/kubernetes-the-documentary-part-1.json
+++ b/generated/kubernetes-the-documentary-part-1.json
@@ -1,8 +1,9 @@
 {
  "name": "Kubernetes: The Documentary [PART 1]",
  "slug": "kubernetes-the-documentary-part-1",
- "link": "https://www.youtube.com/watch?v=BE77h7dmoQU",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=BE77h7dmoQU"
+ },
  "language": [
   "en"
  ],

--- a/generated/kubernetes-the-documentary-part-2.json
+++ b/generated/kubernetes-the-documentary-part-2.json
@@ -1,8 +1,9 @@
 {
  "name": "Kubernetes: The Documentary [PART 2]",
  "slug": "kubernetes-the-documentary-part-2",
- "link": "https://www.youtube.com/watch?v=318elIq37PE",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=318elIq37PE"
+ },
  "language": [
   "en"
  ],

--- a/generated/laravel-origins-a-php-documentary.json
+++ b/generated/laravel-origins-a-php-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "Laravel Origins: A PHP Documentary",
  "slug": "laravel-origins-a-php-documentary",
- "link": "https://www.youtube.com/watch?v=127ng7botO4",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=127ng7botO4"
+ },
  "language": [
   "en"
  ],

--- a/generated/lo-and-behold-reveries-of-the-connected-world.json
+++ b/generated/lo-and-behold-reveries-of-the-connected-world.json
@@ -1,8 +1,9 @@
 {
  "name": "Lo and Behold: Reveries of the Connected World",
  "slug": "lo-and-behold-reveries-of-the-connected-world",
- "link": "https://www.youtube.com/watch?v=q3g3hqNJqpQ",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=q3g3hqNJqpQ"
+ },
  "language": [
   "en"
  ],
@@ -15,9 +16,10 @@
  "localized": {
   "de": {
    "title": "Wovon träumt das Internet?",
-   "link": "https://www.amazon.de/gp/video/detail/B0FVCKCM81/",
    "description": "Die Dokumentation beleuchtet die Evolution des Internets und den Einfluss der weltweiten Vernetzung auf den Alltag. Werner Herzog spricht mit Hackern und Computerexperten - aber auch mit Menschen, die dem Internet den Rücken gekehrt haben.",
-   "platform": "amazon_prime_video"
+   "links": {
+    "amazon_prime_video": "https://www.amazon.de/gp/video/detail/B0FVCKCM81/"
+   }
   }
  },
  "title": "Lo and Behold, Reveries of the Connected World",

--- a/generated/node-js-the-documentary.json
+++ b/generated/node-js-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "Node.js: The Documentary",
  "slug": "node-js-the-documentary",
- "link": "https://www.youtube.com/watch?v=LB8KwiiUGy0",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=LB8KwiiUGy0"
+ },
  "language": [
   "en"
  ],

--- a/generated/prometheus-the-documentary.json
+++ b/generated/prometheus-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "Prometheus: The Documentary",
  "slug": "prometheus-the-documentary",
- "link": "https://www.youtube.com/watch?v=rT4fJNbfe14",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=rT4fJNbfe14"
+ },
  "language": [
   "en"
  ],

--- a/generated/python-the-documentary.json
+++ b/generated/python-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "Python: The Documentary",
  "slug": "python-the-documentary",
- "link": "https://www.youtube.com/watch?v=GfH4QL4VqJ0",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=GfH4QL4VqJ0"
+ },
  "language": [
   "en"
  ],

--- a/generated/react-js-the-documentary.json
+++ b/generated/react-js-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "React.js: The Documentary",
  "slug": "react-js-the-documentary",
- "link": "https://www.youtube.com/watch?v=8pDqJVdNa44",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=8pDqJVdNa44"
+ },
  "language": [
   "en"
  ],

--- a/generated/revolution-os.json
+++ b/generated/revolution-os.json
@@ -1,8 +1,9 @@
 {
  "name": "Revolution OS",
  "slug": "revolution-os",
- "link": "https://www.youtube.com/watch?v=k0RYQVkQmWU",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=k0RYQVkQmWU"
+ },
  "language": [
   "en"
  ],

--- a/generated/ruby-on-rails-the-documentary.json
+++ b/generated/ruby-on-rails-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "Ruby on Rails: The Documentary",
  "slug": "ruby-on-rails-the-documentary",
- "link": "https://www.youtube.com/watch?v=HDKUEXBF3B4",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=HDKUEXBF3B4"
+ },
  "language": [
   "en"
  ],

--- a/generated/silicon-cowboys.json
+++ b/generated/silicon-cowboys.json
@@ -1,8 +1,9 @@
 {
  "name": "Silicon Cowboys",
  "slug": "silicon-cowboys",
- "link": "https://www.netflix.com/title/80104318",
- "platform": "netflix",
+ "links": {
+  "netflix": "https://www.netflix.com/title/80104318"
+ },
  "language": null,
  "subtitles": null,
  "tags": [

--- a/generated/svelte-origins-a-javascript-documentary.json
+++ b/generated/svelte-origins-a-javascript-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "Svelte Origins: A JavaScript Documentary",
  "slug": "svelte-origins-a-javascript-documentary",
- "link": "https://www.youtube.com/watch?v=kMlkCYL9qo0",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=kMlkCYL9qo0"
+ },
  "language": [
   "en"
  ],

--- a/generated/terms-and-conditions-may-apply.json
+++ b/generated/terms-and-conditions-may-apply.json
@@ -1,8 +1,9 @@
 {
  "name": "Terms and Conditions May Apply",
  "slug": "terms-and-conditions-may-apply",
- "link": "https://www.youtube.com/watch?v=hRJEYmodC08",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=hRJEYmodC08"
+ },
  "language": [
   "en"
  ],

--- a/generated/the-cleaners.json
+++ b/generated/the-cleaners.json
@@ -1,8 +1,9 @@
 {
  "name": "The Cleaners",
  "slug": "the-cleaners",
- "link": "https://www.bpb.de/mediathek/video/273199/the-cleaners/",
- "platform": "bpb",
+ "links": {
+  "bpb": "https://www.bpb.de/mediathek/video/273199/the-cleaners/"
+ },
  "language": null,
  "subtitles": null,
  "tags": [

--- a/generated/the-great-hack.json
+++ b/generated/the-great-hack.json
@@ -1,8 +1,9 @@
 {
  "name": "The Great Hack",
  "slug": "the-great-hack",
- "link": "https://www.netflix.com/title/80117542",
- "platform": "netflix",
+ "links": {
+  "netflix": "https://www.netflix.com/title/80117542"
+ },
  "language": [
   "en",
   "de"

--- a/generated/the-internets-own-boy-aaron-swartz.json
+++ b/generated/the-internets-own-boy-aaron-swartz.json
@@ -1,8 +1,9 @@
 {
  "name": "The Internet's Own Boy: The Story of Aaron Swartz",
  "slug": "the-internets-own-boy-the-story-of-aaron-swartz",
- "link": "https://www.youtube.com/watch?v=9vz06QO3UkQ",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=9vz06QO3UkQ"
+ },
  "language": [
   "en"
  ],

--- a/generated/typescript-origins-the-documentary.json
+++ b/generated/typescript-origins-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "TypeScript Origins: The Documentary",
  "slug": "typescript-origins-the-documentary",
- "link": "https://www.youtube.com/watch?v=U6s2pdxebSo",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=U6s2pdxebSo"
+ },
  "language": [
   "en"
  ],

--- a/generated/vite-the-documentary.json
+++ b/generated/vite-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "VITE: The Documentary",
  "slug": "vite-the-documentary",
- "link": "https://www.youtube.com/watch?v=bmWQqAKLgT4",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=bmWQqAKLgT4"
+ },
  "language": [
   "en"
  ],

--- a/generated/vue-js-the-documentary.json
+++ b/generated/vue-js-the-documentary.json
@@ -1,8 +1,9 @@
 {
  "name": "Vue.js: The Documentary",
  "slug": "vue-js-the-documentary",
- "link": "https://www.youtube.com/watch?v=OrxmtDw4pVI",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=OrxmtDw4pVI"
+ },
  "language": [
   "en"
  ],

--- a/generated/we-are-legion-the-story-of-the-hacktivists.json
+++ b/generated/we-are-legion-the-story-of-the-hacktivists.json
@@ -1,8 +1,9 @@
 {
  "name": "We Are Legion: The Story of the Hacktivists",
  "slug": "we-are-legion-the-story-of-the-hacktivists",
- "link": "https://www.youtube.com/watch?v=4D1WJsdu6W8",
- "platform": "youtube",
+ "links": {
+  "youtube": "https://www.youtube.com/watch?v=4D1WJsdu6W8"
+ },
  "language": [
   "en"
  ],

--- a/movies/angular-the-documentary.yml
+++ b/movies/angular-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "Angular: The Documentary"
-link: https://www.youtube.com/watch?v=cRC9DlH45lA
+links:
+  youtube: https://www.youtube.com/watch?v=cRC9DlH45lA
 tags:
   - Frontend
   - JavaScript

--- a/movies/clojure-the-documentary.yml
+++ b/movies/clojure-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "Clojure: The Documentary"
-link: https://www.youtube.com/watch?v=Y24vK_QDLFg
+links:
+  youtube: https://www.youtube.com/watch?v=Y24vK_QDLFg
 tags:
   - Programming Languages
   - Functional Programming

--- a/movies/code-debugging-the-gender-gap.yml
+++ b/movies/code-debugging-the-gender-gap.yml
@@ -1,5 +1,6 @@
 name: "CODE: Debugging the Gender Gap"
-link: https://www.youtube.com/watch?v=rQKRw6tWsb8
+links:
+  youtube: https://www.youtube.com/watch?v=rQKRw6tWsb8
 imdbID: tt4335520
 tags:
   - Girls

--- a/movies/ebpf-unlocking-the-kernel.yml
+++ b/movies/ebpf-unlocking-the-kernel.yml
@@ -1,5 +1,6 @@
 name: "eBPF: Unlocking the Kernel"
-link: https://www.youtube.com/watch?v=Wb_vD3XZYOA
+links:
+  youtube: https://www.youtube.com/watch?v=Wb_vD3XZYOA
 tags:
   - Linux
   - Kernel

--- a/movies/elixir-the-documentary.yml
+++ b/movies/elixir-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "Elixir: The Documentary"
-link: https://www.youtube.com/watch?v=lxYFOM3UJzo
+links:
+  youtube: https://www.youtube.com/watch?v=lxYFOM3UJzo
 tags:
   - Programming Languages
   - Functional Programming

--- a/movies/ember-js-the-documentary.yml
+++ b/movies/ember-js-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "Ember.js: The Documentary"
-link: https://www.youtube.com/watch?v=Cvz-9ccflKQ
+links:
+  youtube: https://www.youtube.com/watch?v=Cvz-9ccflKQ
 tags:
   - Frontend
   - JavaScript

--- a/movies/graphql-the-documentary.yml
+++ b/movies/graphql-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "GraphQL: The Documentary"
-link: https://www.youtube.com/watch?v=783ccP__No8
+links:
+  youtube: https://www.youtube.com/watch?v=783ccP__No8
 tags:
   - API
   - Open Source

--- a/movies/half-life-25th-anniversary-documentary.yml
+++ b/movies/half-life-25th-anniversary-documentary.yml
@@ -1,5 +1,6 @@
 name: "Half-Life: 25th Anniversary Documentary"
-link: https://www.youtube.com/watch?v=TbZ3HzvFEto
+links:
+  youtube: https://www.youtube.com/watch?v=TbZ3HzvFEto
 tags:
   - Game Development
   - Valve

--- a/movies/indie-game-the-movie.yml
+++ b/movies/indie-game-the-movie.yml
@@ -1,5 +1,6 @@
 name: "Indie Game: The Movie"
-link: https://www.netflix.com/title/70229918
+links:
+  netflix: https://www.netflix.com/title/70229918
 imdbID: tt1942884
 youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=dINgx0y4GqM
 tags:

--- a/movies/inside-envoy.yml
+++ b/movies/inside-envoy.yml
@@ -1,5 +1,6 @@
 name: "Inside Envoy: The Proxy for the Future"
-link: https://www.youtube.com/watch?v=uaksVVHDhYU
+links:
+  youtube: https://www.youtube.com/watch?v=uaksVVHDhYU
 tags:
   - Networking
   - Service Mesh

--- a/movies/intellij-idea-the-documentary.yml
+++ b/movies/intellij-idea-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "IntelliJ IDEA: The Documentary"
-link: https://www.youtube.com/watch?v=Kourq_Lz03U
+links:
+  youtube: https://www.youtube.com/watch?v=Kourq_Lz03U
 tags:
   - Developer Tools
   - IDE

--- a/movies/internet-relay-chat-irc.yml
+++ b/movies/internet-relay-chat-irc.yml
@@ -1,5 +1,6 @@
 name: Internet Relay Chat (IRC)
-link: https://www.youtube.com/watch?v=6UbKenFipjo
+links:
+  youtube: https://www.youtube.com/watch?v=6UbKenFipjo
 tags:
   - Networking
   - Chat

--- a/movies/kubernetes-the-documentary-part-1.yml
+++ b/movies/kubernetes-the-documentary-part-1.yml
@@ -1,5 +1,6 @@
 name: "Kubernetes: The Documentary [PART 1]"
-link: https://www.youtube.com/watch?v=BE77h7dmoQU
+links:
+  youtube: https://www.youtube.com/watch?v=BE77h7dmoQU
 tags:
   - Cloud Native
   - Orchestration

--- a/movies/kubernetes-the-documentary-part-2.yml
+++ b/movies/kubernetes-the-documentary-part-2.yml
@@ -1,5 +1,6 @@
 name: "Kubernetes: The Documentary [PART 2]"
-link: https://www.youtube.com/watch?v=318elIq37PE
+links:
+  youtube: https://www.youtube.com/watch?v=318elIq37PE
 tags:
   - Cloud Native
   - Orchestration

--- a/movies/laravel-origins-a-php-documentary.yml
+++ b/movies/laravel-origins-a-php-documentary.yml
@@ -1,5 +1,6 @@
 name: "Laravel Origins: A PHP Documentary"
-link: https://www.youtube.com/watch?v=127ng7botO4
+links:
+  youtube: https://www.youtube.com/watch?v=127ng7botO4
 tags:
   - Web Frameworks
   - PHP

--- a/movies/lo-and-behold-reveries-of-the-connected-world.yml
+++ b/movies/lo-and-behold-reveries-of-the-connected-world.yml
@@ -1,5 +1,6 @@
 name: "Lo and Behold: Reveries of the Connected World"
-link: https://www.youtube.com/watch?v=q3g3hqNJqpQ
+links:
+  youtube: https://www.youtube.com/watch?v=q3g3hqNJqpQ
 imdbID: tt5275828
 tags:
   - Internet
@@ -9,5 +10,6 @@ description: Directed by Werner Herzog, this documentary explores the history, i
 localized:
   de:
     title: Wovon träumt das Internet?
-    link: https://www.amazon.de/gp/video/detail/B0FVCKCM81/
     description: Die Dokumentation beleuchtet die Evolution des Internets und den Einfluss der weltweiten Vernetzung auf den Alltag. Werner Herzog spricht mit Hackern und Computerexperten - aber auch mit Menschen, die dem Internet den Rücken gekehrt haben.
+    links:
+      amazon_prime_video: https://www.amazon.de/gp/video/detail/B0FVCKCM81/

--- a/movies/node-js-the-documentary.yml
+++ b/movies/node-js-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "Node.js: The Documentary"
-link: https://www.youtube.com/watch?v=LB8KwiiUGy0
+links:
+  youtube: https://www.youtube.com/watch?v=LB8KwiiUGy0
 tags:
   - JavaScript
   - Backend

--- a/movies/prometheus-the-documentary.yml
+++ b/movies/prometheus-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "Prometheus: The Documentary"
-link: https://www.youtube.com/watch?v=rT4fJNbfe14
+links:
+  youtube: https://www.youtube.com/watch?v=rT4fJNbfe14
 tags:
   - Observability
   - Monitoring

--- a/movies/python-the-documentary.yml
+++ b/movies/python-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "Python: The Documentary"
-link: https://www.youtube.com/watch?v=GfH4QL4VqJ0
+links:
+  youtube: https://www.youtube.com/watch?v=GfH4QL4VqJ0
 tags:
   - Programming Languages
   - Open Source

--- a/movies/react-js-the-documentary.yml
+++ b/movies/react-js-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "React.js: The Documentary"
-link: https://www.youtube.com/watch?v=8pDqJVdNa44
+links:
+  youtube: https://www.youtube.com/watch?v=8pDqJVdNa44
 tags:
   - Frontend
   - JavaScript

--- a/movies/revolution-os.yml
+++ b/movies/revolution-os.yml
@@ -1,5 +1,6 @@
 name: Revolution OS
-link: https://www.youtube.com/watch?v=k0RYQVkQmWU
+links:
+  youtube: https://www.youtube.com/watch?v=k0RYQVkQmWU
 imdbID: tt0308808
 tags:
   - GNU/Linux

--- a/movies/ruby-on-rails-the-documentary.yml
+++ b/movies/ruby-on-rails-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "Ruby on Rails: The Documentary"
-link: https://www.youtube.com/watch?v=HDKUEXBF3B4
+links:
+  youtube: https://www.youtube.com/watch?v=HDKUEXBF3B4
 tags:
   - Web Frameworks
   - Ruby

--- a/movies/silicon-cowboys.yml
+++ b/movies/silicon-cowboys.yml
@@ -1,5 +1,6 @@
 name: Silicon Cowboys
-link: https://www.netflix.com/title/80104318
+links:
+  netflix: https://www.netflix.com/title/80104318
 imdbID: tt4938484
 youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=7wjJYqUkHd8
 tags:

--- a/movies/svelte-origins-a-javascript-documentary.yml
+++ b/movies/svelte-origins-a-javascript-documentary.yml
@@ -1,5 +1,6 @@
 name: "Svelte Origins: A JavaScript Documentary"
-link: https://www.youtube.com/watch?v=kMlkCYL9qo0
+links:
+  youtube: https://www.youtube.com/watch?v=kMlkCYL9qo0
 tags:
   - Frontend
   - JavaScript

--- a/movies/terms-and-conditions-may-apply.yml
+++ b/movies/terms-and-conditions-may-apply.yml
@@ -1,5 +1,6 @@
 name: Terms and Conditions May Apply
-link: https://www.youtube.com/watch?v=hRJEYmodC08
+links:
+  youtube: https://www.youtube.com/watch?v=hRJEYmodC08
 imdbID: tt2084953
 tags:
   - Privacy

--- a/movies/the-cleaners.yml
+++ b/movies/the-cleaners.yml
@@ -1,5 +1,6 @@
 name: The Cleaners
-link: https://www.bpb.de/mediathek/video/273199/the-cleaners/
+links:
+  bpb: https://www.bpb.de/mediathek/video/273199/the-cleaners/
 imdbID: tt7689936
 youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=iGCGhD8i-o4
 tags:

--- a/movies/the-great-hack.yml
+++ b/movies/the-great-hack.yml
@@ -1,5 +1,6 @@
 name: The Great Hack
-link: https://www.netflix.com/title/80117542
+links:
+  netflix: https://www.netflix.com/title/80117542
 imdbID: tt4736550
 youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=iX8GxLP1FHo
 language:

--- a/movies/the-internets-own-boy-aaron-swartz.yml
+++ b/movies/the-internets-own-boy-aaron-swartz.yml
@@ -1,5 +1,6 @@
 name: "The Internet's Own Boy: The Story of Aaron Swartz"
-link: https://www.youtube.com/watch?v=9vz06QO3UkQ
+links:
+  youtube: https://www.youtube.com/watch?v=9vz06QO3UkQ
 imdbID: tt3268458
 tags:
   - Hacktivism

--- a/movies/typescript-origins-the-documentary.yml
+++ b/movies/typescript-origins-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "TypeScript Origins: The Documentary"
-link: https://www.youtube.com/watch?v=U6s2pdxebSo
+links:
+  youtube: https://www.youtube.com/watch?v=U6s2pdxebSo
 tags:
   - Programming Languages
   - JavaScript

--- a/movies/vite-the-documentary.yml
+++ b/movies/vite-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "VITE: The Documentary"
-link: https://www.youtube.com/watch?v=bmWQqAKLgT4
+links:
+  youtube: https://www.youtube.com/watch?v=bmWQqAKLgT4
 tags:
   - Frontend
   - Build Tools

--- a/movies/vue-js-the-documentary.yml
+++ b/movies/vue-js-the-documentary.yml
@@ -1,5 +1,6 @@
 name: "Vue.js: The Documentary"
-link: https://www.youtube.com/watch?v=OrxmtDw4pVI
+links:
+  youtube: https://www.youtube.com/watch?v=OrxmtDw4pVI
 tags:
   - Frontend
   - JavaScript

--- a/movies/we-are-legion-the-story-of-the-hacktivists.yml
+++ b/movies/we-are-legion-the-story-of-the-hacktivists.yml
@@ -1,5 +1,6 @@
 name: "We Are Legion: The Story of the Hacktivists"
-link: https://www.youtube.com/watch?v=4D1WJsdu6W8
+links:
+  youtube: https://www.youtube.com/watch?v=4D1WJsdu6W8
 imdbID: tt2177843
 description: >-
   This documentary takes a deep dive into the world of Anonymous, a


### PR DESCRIPTION
## Summary
- The single \`link\` / \`platform\` pair on every entry becomes a single \`links\` map keyed by platform slug. Same on \`LocalizedVersion\` — \`link\` and \`platform\` go away there too, replaced by a per-key-merge \`links\` override map.
- README "Watch on" line renders all platforms inline with pipes — \`* Watch on: [YouTube](url) | [Netflix](url)\`. Single-platform entries look identical to today, just with the new \"Watch on:\" prefix.
- The four-warning-branch \`resolvePlatform\` / \`resolveLocalizedPlatforms\` collapse into one \`validateLinks\` pass that warns when a known-slug URL doesn't match its slug. Unknown slugs (e.g. \`vimeo\`) pass through silently.
- All 32 \`movies/*.yml\` migrated to the new schema; all 32 \`generated/*.json\` regenerated.

## Why
A single entry can live on several streaming platforms (YouTube and Netflix and Amazon Prime, …) but the schema only carried one. The user wanted \`link\` to become a map keyed by platform slug, with the same structure on each \`localized.<code>\` to override per-language. With the keys of the map now expressing the platform list directly, the separate \`platform\` field becomes redundant and is removed.

## Decisions confirmed up front
- **README format:** one bullet, inline list with pipes.
- **Localized merge:** per-key — only the platforms listed under \`localized.<code>.links\` override their top-level counterparts; everything else is inherited.
- **\`platform\` field:** dropped, derivable from \`links\` keys.

## Sample output
YAML:
\`\`\`yaml
name: "Lo and Behold: Reveries of the Connected World"
links:
  youtube: https://www.youtube.com/watch?v=q3g3hqNJqpQ
localized:
  de:
    title: Wovon träumt das Internet?
    links:
      amazon_prime_video: https://www.amazon.de/gp/video/detail/B0FVCKCM81/
\`\`\`

JSON:
\`\`\`json
\"links\": {
  \"youtube\": \"https://www.youtube.com/watch?v=q3g3hqNJqpQ\"
},
\"localized\": {
  \"de\": {
    \"title\": \"Wovon träumt das Internet?\",
    \"links\": {
      \"amazon_prime_video\": \"https://www.amazon.de/gp/video/detail/B0FVCKCM81/\"
    }
  }
}
\`\`\`

README:
\`\`\`
* Watch on: [YouTube](https://www.youtube.com/watch?v=q3g3hqNJqpQ)
\`\`\`

## Commit-by-commit
1. \`platform.IsKnown\` helper — slug-exists lookup the validator uses.
2. **Refactor**: drop \`Link\`/\`Platform\` (top-level + LocalizedVersion), add \`Links\` maps, replace resolver functions with \`validateLinks\`, swap YouTube gates / videoID parses to read from \`Links[platform.YouTube]\`, add \`HasLinks\`/\`LinksFormatted\` template helpers, update README template, update all affected tests. Single coherent commit because every dependent site changes together.
3. Migrate \`movies/*.yml\` to the new schema (32 files; \`link:\` → \`links:\` plus the localized.de migration on Lo and Behold).
4. Documentation — CONTRIBUTING.md row swap, inline YAML examples updated.
5. \`chore: Update generated movie content\` — every JSON regenerated; README rewritten with the new Watch line format.

## Test plan
- [x] \`cd app && go build ./... && go vet ./... && go test ./...\` — all passing, including new \`TestIsKnown\`, \`TestValidateLinks\`, \`TestLinksFormatted\`, and the existing precedence tests adapted to the new fixture.
- [x] \`go run . convertYamlToJson …\` — silent on warnings; every entry's URL matches its slug.
- [x] Spot-checked Lo and Behold's JSON: top-level \`links.youtube\`, \`localized.de.links.amazon_prime_video\` — round-tripped.
- [x] README spot-check: every entry now reads \`* Watch on: [Platform](url)\`; the four non-YouTube entries show their respective platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)