### PR TITLE
Revise CONTRIBUTING acceptance criteria for the current dataset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,22 +15,37 @@ An entry is a good fit if it meets **at least one** of the following:
   typical conference session.
 - Educational content broadly relevant to software engineers (e.g.
   the inner workings of the internet, distributed systems, security,
-  hardware).
+  hardware, content moderation, surveillance).
 
 In addition, the entry should be:
 
-- Freely viewable.
-- At least 15 minutes long.
-- Published more than 2 weeks ago (gives the community time to react
-  to clickbait/low-quality posts).
+- **Watchable on a mainstream platform.** Free with optional ads
+  (YouTube), bundled with a common subscription (Netflix, Amazon
+  Prime Video, …), or on a public broadcaster's media library
+  (e.g. bpb). Pay-per-rent on a major store (Apple TV, Prime Video
+  rental) is acceptable; obscure regional rentals or short
+  film-festival exclusives are not. List **every** platform the
+  entry is available on in the `links:` map.
+- **At least 15 minutes long.**
+- **Published more than 2 weeks ago.** Gives the community time to
+  react to clickbait or low-quality posts.
+- **Accessible in English** — either English audio or English
+  subtitles. Other-language uploads of the same entry can be added
+  via the `localized:` block (see below); the top-level entry must
+  still be the English version.
 
 Out of scope for now:
 
 - Short tutorials or "build X in 10 minutes" videos.
 - Conference talks unless they are explicitly long-form / documentary
   in nature.
-- Content not in a language any reasonable engineer can follow
-  (use the `language` field to be explicit).
+- Content with no English audio and no English subtitles.
+- Purely fictional movies / TV series — invented characters and
+  plots, even with a tech setting (e.g. *Mr. Robot*, *Halt and
+  Catch Fire*, cyber-thrillers). Biopics and dramatised true
+  stories about real engineers or real events (e.g. *The Social
+  Network*, *Pirates of Silicon Valley*) ARE in scope; use
+  `type: Movie` for those.
 
 ## How to add an entry
 


### PR DESCRIPTION
## Summary
The acceptance criteria in CONTRIBUTING.md predated Netflix / Amazon Prime / bpb entries and the \`localized:\` infrastructure. Several rules were factually wrong; this PR rewrites the affected rules to match what the catalogue actually accepts today.

## What changed
- **\"Freely viewable\" → \"Watchable on a mainstream platform.\"** Free ad-supported (YouTube), common subscriptions (Netflix, Amazon Prime Video), public-broadcaster libraries (bpb), and pay-per-rent on a major store are all in scope; obscure regional rentals and short festival exclusives are not. The clause now mentions the \`links:\` map so contributors know where to declare every platform.
- **\"Educational content\" examples extended** to include content moderation and surveillance, matching The Cleaners / The Great Hack / Terms and Conditions May Apply.
- **\"Accessible in English\" is now an explicit clause**, with a pointer to \`localized:\` for alternate-language uploads of the same work.
- **New out-of-scope bullet excluding PURELY fictional movies / TV series.** Biopics and dramatised true stories (*The Social Network*, *Pirates of Silicon Valley*) stay in scope under \`type: Movie\`; only fully invented plots (Mr. Robot, Halt and Catch Fire, cyber-thrillers) are out.

## What did NOT change
- The four positive criteria. They still describe the catalogue accurately.
- The 15-minute length floor.
- The \"published more than 2 weeks ago\" clause.

## Audit against current entries
Every catalogued entry (32) passes the new rules. Spot checks:
- The Great Hack (Netflix) — passes \"Watchable on a mainstream platform\" via the Netflix subscription clause.
- The Cleaners (bpb) — passes via the public-broadcaster clause.
- Lo and Behold — top-level YouTube link satisfies the platform rule; the Amazon Prime Video German upload lives in \`localized.de.links\` per the \"alternate-language uploads\" guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)