### PR TITLE
Add 16 new movies and HBO Max, Apple TV, RTL+ platform support

### DIFF
--- a/app/platform/platform.go
+++ b/app/platform/platform.go
@@ -19,6 +19,9 @@ const (
 	Netflix          = "netflix"
 	AmazonPrimeVideo = "amazon_prime_video"
 	BPB              = "bpb"
+	HBOMax           = "hbo_max"
+	AppleTV          = "apple_tv"
+	RTLPlus          = "rtl_plus"
 )
 
 // displayNames maps slugs to the human-readable names rendered into
@@ -30,6 +33,9 @@ var displayNames = map[string]string{
 	Netflix:          "Netflix",
 	AmazonPrimeVideo: "Amazon Prime Video",
 	BPB:              "Bundeszentrale für politische Bildung",
+	HBOMax:           "HBO Max",
+	AppleTV:          "Apple TV",
+	RTLPlus:          "RTL+",
 }
 
 // Detect inspects a link and returns the platform slug it belongs to,
@@ -64,8 +70,12 @@ func Detect(link string) (string, bool) {
 	// Amazon Prime Video: any amazon.<tld> host where the path lives
 	// under /gp/video/ or /video/. The host alone is not enough —
 	// amazon.de also serves books and physical goods.
+	// primevideo.com is the dedicated Prime Video host (any /detail/
+	// page); it is video-only so the host check is sufficient.
 	case strings.HasPrefix(host, "amazon.") &&
 		(strings.HasPrefix(path, "/gp/video/") || strings.HasPrefix(path, "/video/")):
+		return AmazonPrimeVideo, true
+	case host == "primevideo.com" && strings.Contains(path, "/detail/"):
 		return AmazonPrimeVideo, true
 
 	// bpb: Bundeszentrale für politische Bildung media library.
@@ -73,6 +83,24 @@ func Detect(link string) (string, bool) {
 	// (essays, dossiers) we don't want to misclassify.
 	case host == "bpb.de" && strings.HasPrefix(path, "/mediathek/"):
 		return BPB, true
+
+	// HBO Max: WB's streaming service, with both the legacy
+	// play.hbomax.com domain and the newer max.com brand.
+	case (host == "play.hbomax.com" || host == "hbomax.com" || host == "max.com") &&
+		(strings.HasPrefix(path, "/video/") || strings.HasPrefix(path, "/title/") || strings.HasPrefix(path, "/movie/") || strings.HasPrefix(path, "/show/")):
+		return HBOMax, true
+
+	// Apple TV: tv.apple.com hosts both the rental store and the
+	// Apple TV+ subscription catalogue. URLs include a locale segment
+	// (e.g. /de/movie/...), so match on the substring rather than
+	// the path prefix.
+	case host == "tv.apple.com" &&
+		(strings.Contains(path, "/movie/") || strings.Contains(path, "/show/") || strings.Contains(path, "/episode/")):
+		return AppleTV, true
+
+	// RTL+: German free + premium streaming service.
+	case host == "plus.rtl.de":
+		return RTLPlus, true
 	}
 
 	return "", false

--- a/app/platform/platform_test.go
+++ b/app/platform/platform_test.go
@@ -25,6 +25,18 @@ func TestDetect(t *testing.T) {
 		{"amazon co.uk video", "https://www.amazon.co.uk/gp/video/detail/abc", AmazonPrimeVideo, true},
 		{"amazon product page not detected", "https://www.amazon.de/dp/B08XXX", "", false},
 		{"amazon home not detected", "https://www.amazon.com/", "", false},
+		{"primevideo locale detail", "https://www.primevideo.com/-/de/detail/0GLUAOADBR7IWUD0NZPU7JFI11", AmazonPrimeVideo, true},
+		{"primevideo bare host root not detected", "https://www.primevideo.com/", "", false},
+
+		{"hbomax play title", "https://play.hbomax.com/video/watch/60158ef5", HBOMax, true},
+		{"max.com title", "https://www.max.com/title/abc123", HBOMax, true},
+		{"hbomax bare host root not detected", "https://play.hbomax.com/", "", false},
+
+		{"apple tv movie", "https://tv.apple.com/de/movie/print-the-legend/umc.cmc.4ca9", AppleTV, true},
+		{"apple tv show", "https://tv.apple.com/us/show/foundation/umc.cmc.x", AppleTV, true},
+		{"apple tv root not detected", "https://tv.apple.com/de", "", false},
+
+		{"rtl plus", "https://plus.rtl.de/picture-a-scientist-frauen-der-wissenschaft-p_1014", RTLPlus, true},
 
 		{"bpb mediathek", "https://www.bpb.de/mediathek/video/273199/the-cleaners/", BPB, true},
 		{"bpb bare host", "https://bpb.de/mediathek/video/123/foo/", BPB, true},
@@ -50,6 +62,9 @@ func TestIsKnown(t *testing.T) {
 		Netflix:          true,
 		AmazonPrimeVideo: true,
 		BPB:              true,
+		HBOMax:           true,
+		AppleTV:          true,
+		RTLPlus:          true,
 		"vimeo":          false,
 		"":               false,
 	}
@@ -66,6 +81,9 @@ func TestDisplay(t *testing.T) {
 		Netflix:          "Netflix",
 		AmazonPrimeVideo: "Amazon Prime Video",
 		BPB:              "Bundeszentrale für politische Bildung",
+		HBOMax:           "HBO Max",
+		AppleTV:          "Apple TV",
+		RTLPlus:          "RTL+",
 		"":               "",
 		"vimeo":          "vimeo", // unknown slug → returned verbatim
 	}

--- a/movies/alphago.yml
+++ b/movies/alphago.yml
@@ -1,0 +1,12 @@
+name: AlphaGo - The Movie
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=WXuK6gekU1Y
+imdbID: tt6700846
+tags:
+  - AI
+  - Machine Learning
+  - DeepMind
+  - Games
+description: With more board configurations than there are atoms in the universe, the ancient Chinese game of Go has long been considered a grand challenge for artificial intelligence. This film follows DeepMind's AlphaGo as it takes on legendary Go champion Lee Sedol in a five-game match in Seoul.

--- a/movies/atari-game-over.yml
+++ b/movies/atari-game-over.yml
@@ -1,0 +1,15 @@
+name: "ATARI: Game Over"
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=84rx7-jCdAY
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.d85059f3-e120-421e-9125-adfd5e48f0a1
+  apple_tv: https://tv.apple.com/de/movie/atari-game-over/umc.cmc.3xa62786lun35w67960lp2a25
+imdbID: tt3715406
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=lnyoyWpqKJI
+tags:
+  - Gaming
+  - History
+  - Atari
+  - Hardware
+description: A crew search for all of the old Atari 2600 game cartridges of "E.T. the Extra-Terrestrial" that were tossed into a landfill in the 1980s.

--- a/movies/coded-bias.yml
+++ b/movies/coded-bias.yml
@@ -1,0 +1,20 @@
+name: Coded Bias
+type: Documentary
+category: Culture / Society
+links:
+  netflix: https://www.netflix.com/title/81328723
+  amazon_prime_video: https://www.primevideo.com/-/de/detail/0GLUAOADBR7IWUD0NZPU7JFI11
+imdbID: tt11394170
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=rf68wQDVEho
+language:
+  - en
+  - de
+tags:
+  - AI
+  - Algorithmic Bias
+  - Privacy
+  - Society
+description: When MIT Media Lab researcher Joy Buolamwini discovers that facial recognition does not see dark-skinned faces accurately, she embarks on a journey to push for the first-ever U.S. legislation against bias in algorithms that impact us all.
+localized:
+  de:
+    title: Vorprogrammierte Diskriminierung

--- a/movies/countdown-inspiration4-mission-to-space.yml
+++ b/movies/countdown-inspiration4-mission-to-space.yml
@@ -1,0 +1,19 @@
+name: "Countdown: Inspiration4 Mission to Space"
+type: Documentary
+category: Culture / Society
+links:
+  netflix: https://www.netflix.com/title/81441273
+imdbID: tt15679706
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=D38W150h9a4
+language:
+  - en
+  - de
+tags:
+  - Space
+  - SpaceX
+  - Engineering
+  - History
+description: A trailblazing mission captured in near-real time as four crew members make history in the first all-civilian mission into orbit.
+localized:
+  de:
+    title: "Countdown: Die Weltraummission Inspiration4"

--- a/movies/deep-web.yml
+++ b/movies/deep-web.yml
@@ -1,0 +1,19 @@
+name: Deep Web
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=w4P-eW0UdKo
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.08b3c0a6-d2f2-65d1-a49d-4063ffe2d328
+imdbID: tt3312868
+language:
+  - en
+  - de
+tags:
+  - Security
+  - Tor
+  - Cryptocurrency
+  - Society
+description: A feature documentary that explores the rise of a new Internet; decentralized, encrypted, dangerous and beyond the law; with particular focus on the FBI capture of the Tor hidden service Silk Road, and the judicial aftermath.
+localized:
+  de:
+    title: Deep Web - Der Untergang der Silk Road

--- a/movies/general-magic.yml
+++ b/movies/general-magic.yml
@@ -1,0 +1,19 @@
+name: General Magic
+type: Documentary
+category: Culture / People
+links:
+  youtube: https://www.youtube.com/watch?v=tuFl4WEXBrk
+imdbID: tt6849786
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=uTdyb-RWNKo
+language:
+  - en
+  - de
+tags:
+  - Apple
+  - Startups
+  - History
+  - Silicon Valley
+description: The story of the most influential Silicon Valley startup nobody has ever heard of. General Magic spun out of Apple in 1990 to create the precursor of the smartphone, but the world wasn't ready - the fame and fortune went to others years later with similar products.
+localized:
+  de:
+    description: Diese Dokumentation erzählt die Geschichte von drei Tüftlern, die vor fast 30 Jahren einen Vorreiter des Handys auf den Markt bringen wollten. Die Welt war jedoch offenbar noch nicht bereit für die visionäre Idee - den Ruhm und das große Geld fuhren Jahre später mit einem ähnlichen Produkt andere ein.

--- a/movies/i-am-human.yml
+++ b/movies/i-am-human.yml
@@ -1,0 +1,13 @@
+name: "I Am Human: A Documentary About Real-Life Cyborgs"
+type: Documentary
+category: Culture / Society
+links:
+  amazon_prime_video: https://www.primevideo.com/-/es/detail/0MN9YN2HGYGM3QOUBQV2MQNX0F
+imdbID: tt9114286
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=7zTE1Mss8Xo
+tags:
+  - Hardware
+  - Brain-Computer Interface
+  - Health Tech
+  - Ethics
+description: I Am Human (2019) is a documentary exploring the lives of three individuals - Bill, Anne, and Stephen - who become some of the first "real-life cyborgs" through experimental brain implant technology. Directed by Elena Gaby and Taryn Southern, it examines the personal, ethical, and societal implications of merging human consciousness with machines to treat paralysis, Parkinson's, and blindness.

--- a/movies/inside-bills-brain-decoding-bill-gates.yml
+++ b/movies/inside-bills-brain-decoding-bill-gates.yml
@@ -1,0 +1,19 @@
+name: "Inside Bill's Brain: Decoding Bill Gates"
+type: Documentary
+category: Culture / People
+links:
+  netflix: https://www.netflix.com/title/80184771
+imdbID: tt10970908
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=aCv29JKmHNY
+language:
+  - en
+  - de
+tags:
+  - Microsoft
+  - Bill Gates
+  - History
+  - Philanthropy
+description: A documentary that tells Bill Gates' life story as he pursues solutions to some of the world's most complex problems.
+localized:
+  de:
+    title: Der Mensch Bill Gates

--- a/movies/picture-a-scientist.yml
+++ b/movies/picture-a-scientist.yml
@@ -1,0 +1,22 @@
+name: Picture a Scientist
+type: Documentary
+category: Culture / Society
+links:
+  amazon_prime_video: https://www.primevideo.com/-/de/detail/Picture-a-Scientist/0R4BAWV31M206XNU7LVNH5Y6VS
+  rtl_plus: https://plus.rtl.de/picture-a-scientist-frauen-der-wissenschaft-p_1014
+imdbID: tt9612572
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=Dg2Lyu_nWnk
+language:
+  - en
+  - de
+tags:
+  - Science
+  - Diversity
+  - Society
+  - Academia
+description: Despite the minimal news coverage, sexual harassment and gender inequality against women are no less prevalent in science than they are in pop culture and corporate America.
+localized:
+  de:
+    title: Picture a Scientist - Frauen der Wissenschaft
+    links:
+      amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.c440c255-632b-4ff0-84e1-6835b1abaf4b

--- a/movies/print-the-legend.yml
+++ b/movies/print-the-legend.yml
@@ -1,0 +1,14 @@
+name: Print the Legend
+type: Documentary
+category: Culture / Society
+links:
+  netflix: https://www.netflix.com/title/80005444
+  apple_tv: https://tv.apple.com/de/movie/print-the-legend/umc.cmc.4ca9o2wed84i5ptt1fccfu91o
+imdbID: tt2433174
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=JeqT2NvTFSw
+tags:
+  - Hardware
+  - 3D Printing
+  - Startups
+  - Maker Culture
+description: Follows the people racing to bring the hot new 3D printing technology to your home, documenting the "Macintosh Moment" of this revolution and exploring what it takes to live the American Dream.

--- a/movies/steve-jobs-the-man-in-the-machine.yml
+++ b/movies/steve-jobs-the-man-in-the-machine.yml
@@ -1,0 +1,14 @@
+name: "Steve Jobs: The Man in the Machine"
+type: Documentary
+category: Culture / People
+links:
+  youtube: https://www.youtube.com/watch?v=S4J9e7W68g4
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.45bf1a90-eeb6-43aa-8ef2-0ecf4214f15d
+  apple_tv: https://tv.apple.com/de/movie/steve-jobs-the-man-in-the-machine/umc.cmc.23g7yoaqagwspdsdk2rnozy5
+imdbID: tt3268458
+tags:
+  - Apple
+  - Steve Jobs
+  - History
+  - Silicon Valley
+description: A look at the personal and private life of the late Apple CEO, Steve Jobs.

--- a/movies/the-billion-dollar-code.yml
+++ b/movies/the-billion-dollar-code.yml
@@ -1,0 +1,16 @@
+name: The Billion Dollar Code
+type: TV Series
+category: Culture / People
+links:
+  netflix: https://www.netflix.com/title/81074012
+imdbID: tt15392936
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=iDvPvqImb-4
+language:
+  - en
+  - de
+tags:
+  - Startups
+  - History
+  - Patents
+  - Open Source
+description: No one knows this story. In Berlin in the 90s, two friends, Carsten and Juri, create Terra Vision, something that seemed impossible at the time - the precursor to Google Earth. 25 years later, the German computer nerds are facing the global corporation in court. The Billion Dollar Code, based on a true story.

--- a/movies/the-inventor-out-for-blood-in-silicon-valley.yml
+++ b/movies/the-inventor-out-for-blood-in-silicon-valley.yml
@@ -1,0 +1,20 @@
+name: "The Inventor: Out for Blood in Silicon Valley"
+type: Documentary
+category: Culture / People
+links:
+  hbo_max: https://play.hbomax.com/video/watch/60158ef5-c8c8-4d15-8d61-211d6e97e42c
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.68c2a9a4-b9b2-4b6d-a7cb-8d1f2f6a1b11
+imdbID: tt8488126
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=wtDaP18OGfw
+language:
+  - en
+  - de
+tags:
+  - Startups
+  - Fraud
+  - Silicon Valley
+  - Health Tech
+description: The story of Theranos, a multi-billion dollar tech company, its founder Elizabeth Holmes, the youngest self-made female billionaire, and the massive fraud that collapsed the company.
+localized:
+  de:
+    title: Die Erfinderin - Böses Blut im Silicon Valley

--- a/movies/the-king-of-kong-a-fistful-of-quarters.yml
+++ b/movies/the-king-of-kong-a-fistful-of-quarters.yml
@@ -1,0 +1,18 @@
+name: "The King of Kong: A Fistful of Quarters"
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=lXLQqcHcJDQ
+imdbID: tt0923752
+language:
+  - en
+  - de
+tags:
+  - Gaming
+  - Arcade
+  - History
+  - Competition
+description: Die-hard gamers compete to break world records on classic arcade games. A dedicated teacher attempts to break the world record for Donkey Kong, challenging the long-standing champion. This documentary explores the intense rivalries, precise strategies, and personal sacrifices involved in professional competitive gaming.
+localized:
+  de:
+    description: The King of Kong - A Fistful of Quarters ist ein US-amerikanischer Dokumentarfilm aus dem Jahr 2007. Er handelt von zwei Videospielern, die um den Weltrekord im Spiel Donkey Kong konkurrieren.

--- a/movies/the-rise-of-uk-fintech.yml
+++ b/movies/the-rise-of-uk-fintech.yml
@@ -1,0 +1,20 @@
+name: The Rise of UK Fintech
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=59erwsHe5CI
+tags:
+  - Fintech
+  - Startups
+  - Banking
+  - Regulation
+description: >-
+  The Rise of UK Fintech is a documentary that explores how the UK
+  created a thriving fintech ecosystem from the ashes of the 2008
+  financial crisis. Hear from the founders and CEOs of the UK's
+  biggest fintechs such as Monzo, Starling, Revolut, OakNorth, as
+  well as leaders from the FCA, Bank of England, and more. The 2008
+  financial crisis brought so many countries in the world to the edge
+  of insolvency, but the UK saw this as a chance for reform, and
+  completely overhauled its banking sector to create one of the most
+  enviable fintech ecosystems in the world.

--- a/movies/the-social-dilemma.yml
+++ b/movies/the-social-dilemma.yml
@@ -1,0 +1,30 @@
+name: The Social Dilemma
+type: Documentary
+category: Culture / Society
+links:
+  netflix: https://www.netflix.com/title/81254224
+imdbID: tt11464826
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=uaaC57tcci0
+language:
+  - en
+  - de
+tags:
+  - Social Media
+  - Privacy
+  - Society
+  - Ethics
+description: >-
+  The Social Dilemma is a powerful exploration of the disproportionate
+  impact that a relatively small number of engineers in Silicon Valley
+  have over the way we think, act, and live our lives. The film deftly
+  tackles an underlying cause of viral conspiracy theories, teenage
+  mental health issues, rampant misinformation and political
+  polarization. Through a combination of documentary investigation and
+  narrative drama, the filmmakers expose the hidden machinations behind
+  everyone's favorite social media and search platforms, featuring
+  interviews with high-profile tech whistleblowers including Tristan
+  Harris, Justin Rosenstein, Tim Kendall, Cathy O'Neil, and Rashida
+  Richardson.
+localized:
+  de:
+    title: Das Dilemma mit den sozialen Medien

--- a/movies/we-are-legion-the-story-of-the-hacktivists.yml
+++ b/movies/we-are-legion-the-story-of-the-hacktivists.yml
@@ -14,3 +14,7 @@ tags:
   - Hacktivism
   - Security
   - History
+localized:
+  de:
+    title: We Are Legion - Die Geschichte der Anonymous-Hacker
+    description: Ein Dokumentarfilm über die Arbeitsweise und Überzeugungen des selbsternannten „Hacktivisten"-Kollektivs Anonymous.


### PR DESCRIPTION
## Summary

- Adds **16 new movie entries** spanning AI, fintech, gaming, Silicon Valley history, and society documentaries (Coded Bias, The Inventor, AlphaGo, The Billion Dollar Code, The Social Dilemma, Countdown: Inspiration4, Picture a Scientist, Print the Legend, The Rise of UK Fintech, Inside Bill's Brain, Deep Web, Steve Jobs: The Man in the Machine, ATARI: Game Over, The King of Kong, General Magic, I Am Human).
- Adds **three new platforms** to the `platform` package — HBO Max (`hbo_max`), Apple TV (`apple_tv`) and RTL+ (`rtl_plus`) — with detectors, display names, and tests.
- Extends the **Amazon Prime Video** detector to recognise `primevideo.com` URLs (needed for the *Coded Bias* English link).
- Adds a **German `localized.de` block** to the existing *We Are Legion* entry (German title + synopsis).

## Test plan

- [x] `go test ./...` is green (new platform detector cases and existing YAML→JSON roundtrip tests).
- [x] `convertYamlToJson` runs cleanly over `movies/` with no slug/URL mismatch warnings.
- [ ] CI's `yaml-lint`, `render-readme`, and `testing` workflows pass.
- [ ] After merge, the next `movie-data` enrichment run pulls thumbnails / channel info / IMDb ratings for the new entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)