### PR TITLE
Add 9 movies on privacy, hacking, gaming and crypto

### DIFF
--- a/movies/citizenfour.yml
+++ b/movies/citizenfour.yml
@@ -1,0 +1,25 @@
+name: Citizenfour
+type: Documentary
+category: Culture / Society
+links:
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.a6a9f6d0-0526-a3e1-5a02-94d192a82cd2
+  rtl_plus: https://plus.rtl.de/citizenfour-p_252
+imdbID: tt4044364
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=rHaWhUjV96M
+language:
+  - en
+  - de
+tags:
+  - Privacy
+  - Surveillance
+  - Security
+  - Whistleblowing
+description: >-
+  Citizenfour is a real-time thriller, giving audiences an exclusive
+  front-row seat to the moment Edward Snowden changed history with
+  his revelations of widespread government surveillance around the
+  world. In June 2013, filmmaker Laura Poitras and journalist Glenn
+  Greenwald met with Snowden confidentially in Hong Kong, where he
+  handed over classified documents providing evidence of mass
+  indiscriminate and illegal invasions of privacy by the National
+  Security Agency (NSA).

--- a/movies/free-to-play.yml
+++ b/movies/free-to-play.yml
@@ -1,0 +1,14 @@
+name: Free to Play
+type: Documentary
+category: Culture / People
+links:
+  youtube: https://www.youtube.com/watch?v=UjZYMI1zB9s
+  netflix: https://www.netflix.com/title/81438157
+  apple_tv: https://tv.apple.com/de/movie/free-to-play/umc.cmc.3ti8vrr7ooltzqkij17ovd4xx
+imdbID: tt3203290
+tags:
+  - Gaming
+  - eSports
+  - Dota 2
+  - Valve
+description: Three professional gamers from different parts of the world fight personal hardship to compete in the first Dota 2 International tournament with a million-dollar grand prize. A Valve-produced documentary chronicling the rise of competitive eSports.

--- a/movies/minecraft-the-story-of-mojang.yml
+++ b/movies/minecraft-the-story-of-mojang.yml
@@ -1,0 +1,12 @@
+name: "Minecraft: The Story of Mojang"
+type: Documentary
+category: Culture / People
+links:
+  youtube: https://www.youtube.com/watch?v=ggCIGOQloY4
+imdbID: tt2299435
+tags:
+  - Gaming
+  - Minecraft
+  - Indie
+  - History
+description: Since its development in 2009, Minecraft has taken the digital world by storm. It's now played by millions of people on a global scale. With exclusive interviews from YouTube celebrities and industry experts, this documentary takes an in-depth look at how one game took over the gaming world and follows the story of Mojang, the small Swedish studio behind it.

--- a/movies/particle-fever.yml
+++ b/movies/particle-fever.yml
@@ -1,0 +1,21 @@
+name: Particle Fever
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=WWhHlxhNn58
+  netflix: https://www.netflix.com/title/70296323
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.d0a9f6bd-4024-e2a9-6abb-567e60e33f6f
+  rtl_plus: https://plus.rtl.de/particle-fever-die-jagd-nach-dem-higgs-p_899
+imdbID: tt2125566
+language:
+  - en
+  - de
+tags:
+  - Science
+  - Physics
+  - CERN
+  - Engineering
+description: As the Large Hadron Collider is about to be launched for the first time, physicists are on the cusp of the greatest scientific discovery of all time - or perhaps their greatest failure.
+localized:
+  de:
+    title: Particle Fever - Die Jagd nach dem Higgs

--- a/movies/the-hacker-wars.yml
+++ b/movies/the-hacker-wars.yml
@@ -1,0 +1,20 @@
+name: The Hacker Wars
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=VPYci82ZzW0
+imdbID: tt3565606
+tags:
+  - Hacktivism
+  - Security
+  - Anonymous
+  - Whistleblowing
+description: >-
+  The Hacker Wars is an eye-opening documentary that reveals the
+  high-stakes world of hacking, cyberwarfare, and digital activism.
+  From underground hacker groups to government cyber defense teams,
+  the film uncovers the real battles being fought in cyberspace -
+  the rise of hacktivism and cyber resistance movements, how
+  hackers exploit vulnerabilities to challenge powerful institutions,
+  the blurred line between cybercrime and cyber defense, and why
+  cybersecurity has become a global arms race.

--- a/movies/tpb-afk-the-pirate-bay-away-from-keyboard.yml
+++ b/movies/tpb-afk-the-pirate-bay-away-from-keyboard.yml
@@ -1,0 +1,12 @@
+name: "TPB AFK: The Pirate Bay Away From Keyboard"
+type: Documentary
+category: Culture / People
+links:
+  youtube: https://www.youtube.com/watch?v=ui-w6ZUCzj8
+imdbID: tt2608732
+tags:
+  - File Sharing
+  - Open Source
+  - Internet Freedom
+  - History
+description: The documentary about the founders of The Pirate Bay. An intellectual freedoms documentary based around the interpersonal triumphs and defeats of the three main characters against the largest industry in the known universe - the media industry.

--- a/movies/ulterior-states.yml
+++ b/movies/ulterior-states.yml
@@ -1,0 +1,11 @@
+name: Ulterior States
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=yQGQXy0RIIo
+tags:
+  - Cryptocurrency
+  - Open Source
+  - Decentralization
+  - Activism
+description: Ulterior States (2015) is a self-funded documentary by Free Software developer Dyne.org exploring the decentralized cryptocurrency culture from 2012-2015, highlighting code as activism, digital currency, and future community-governed micro-states. The film collages, rather than dictates, a vision of the emerging crypto landscape.

--- a/movies/we-live-in-public.yml
+++ b/movies/we-live-in-public.yml
@@ -1,0 +1,13 @@
+name: We Live in Public
+type: Documentary
+category: Culture / Society
+links:
+  amazon_prime_video: https://www.primevideo.com/-/de/detail/We-Live-In-Public/0U7M85IDXG9VFNCL3YF9E0N5VP
+imdbID: tt1326201
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=N1cSbsJ5h1I
+tags:
+  - Internet
+  - Privacy
+  - Society
+  - History
+description: We Live In Public is a 2009 documentary film by Ondi Timoner about Internet pioneer Josh Harris, indirectly highlighting the loss of privacy in the Internet age.

--- a/movies/we-steal-secrets-the-story-of-wikileaks.yml
+++ b/movies/we-steal-secrets-the-story-of-wikileaks.yml
@@ -1,0 +1,20 @@
+name: "We Steal Secrets: The Story of WikiLeaks"
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=Qhn_3WNhxEc
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.eca9f6cb-646d-7bdf-fe60-44b2f2f57933
+imdbID: tt2391809
+language:
+  - en
+  - de
+tags:
+  - WikiLeaks
+  - Whistleblowing
+  - Security
+  - Journalism
+description: A documentary that details the creation of Julian Assange's controversial website, which facilitated the largest security breach in U.S. history.
+localized:
+  de:
+    title: "We Steal Secrets: Die WikiLeaks Geschichte"
+    description: Dokumentarfilmer und Oscar-Preisträger Alex Gibney drehte diesen nervenaufreibenden und fesselnden Thriller um Julian Assange und die Erschaffung von WikiLeaks, der umstrittenen Website, die den größten Sicherheitsverstoß in der US-Geschichte möglich machte. Assanges Auf- und Abstieg wird dem des Gefr. Bradley Manning gegenübergestellt, jenem aufgewühlten jungen Soldaten, der 100.000e Geheimdokumente veröffentlichte. "We Steal Secrets - Die WikiLeaks Geschichte" ist ein vielschichtiger Enthüllungsfilm über Transparenz im Informationszeitalter und unseren ewigen Kampf um Wahrheitsfindung.


### PR DESCRIPTION
## Summary

Adds nine new community-suggested entries:

- **We Live in Public** — Josh Harris and the loss of privacy in the Internet age.
- **Citizenfour** — Laura Poitras' real-time Snowden documentary.
- **Particle Fever** — physicists at the LHC chase the Higgs boson.
- **We Steal Secrets: The Story of WikiLeaks** — Alex Gibney on Assange and Manning.
- **Free to Play** — Valve's documentary on the first Dota 2 International.
- **TPB AFK: The Pirate Bay Away From Keyboard** — the Pirate Bay founders' trial.
- **The Hacker Wars** — hacktivism, cyberwarfare, and the state.
- **Minecraft: The Story of Mojang** — how a Swedish indie game took over the world.
- **Ulterior States** — Dyne.org's documentary on early decentralized crypto culture.

German titles / descriptions and alternate German platform links are captured via `localized.de` where applicable (Particle Fever, We Steal Secrets). IMDb tconsts are set so the enrichment job can pull ratings, and `youtubeTrailerForThumbnail` is set on Amazon-only / Netflix-only entries so the README still gets a poster.

## Test plan

- [x] `go test ./...` is green.
- [x] `convertYamlToJson` over `movies/` runs cleanly with no slug/URL mismatch warnings.
- [ ] CI's `yaml-lint`, `render-readme`, and `testing` workflows pass.
- [ ] After merge, the next `movie-data` enrichment run pulls thumbnails / channel info / IMDb ratings for the new entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)