### PR TITLE
Add 6 movies + broaden HBO Max URL detector

### DIFF
--- a/app/platform/platform.go
+++ b/app/platform/platform.go
@@ -85,9 +85,12 @@ func Detect(link string) (string, bool) {
 		return BPB, true
 
 	// HBO Max: WB's streaming service, with both the legacy
-	// play.hbomax.com domain and the newer max.com brand.
+	// play.hbomax.com domain and the newer max.com brand. Catalogue
+	// URLs include a locale prefix on hbomax.com
+	// (e.g. /tr/en/movies/...), so match on substrings rather than
+	// the path prefix.
 	case (host == "play.hbomax.com" || host == "hbomax.com" || host == "max.com") &&
-		(strings.HasPrefix(path, "/video/") || strings.HasPrefix(path, "/title/") || strings.HasPrefix(path, "/movie/") || strings.HasPrefix(path, "/show/")):
+		(strings.Contains(path, "/video/") || strings.Contains(path, "/title/") || strings.Contains(path, "/movie/") || strings.Contains(path, "/movies/") || strings.Contains(path, "/show/") || strings.Contains(path, "/series/")):
 		return HBOMax, true
 
 	// Apple TV: tv.apple.com hosts both the rental store and the

--- a/app/platform/platform_test.go
+++ b/app/platform/platform_test.go
@@ -30,6 +30,7 @@ func TestDetect(t *testing.T) {
 
 		{"hbomax play title", "https://play.hbomax.com/video/watch/60158ef5", HBOMax, true},
 		{"max.com title", "https://www.max.com/title/abc123", HBOMax, true},
+		{"hbomax locale movies", "https://www.hbomax.com/tr/en/movies/kill-chain/abc", HBOMax, true},
 		{"hbomax bare host root not detected", "https://play.hbomax.com/", "", false},
 
 		{"apple tv movie", "https://tv.apple.com/de/movie/print-the-legend/umc.cmc.4ca9", AppleTV, true},

--- a/movies/app-the-human-story.yml
+++ b/movies/app-the-human-story.yml
@@ -1,0 +1,13 @@
+name: "App: The Human Story"
+type: Documentary
+category: Culture / People
+links:
+  amazon_prime_video: https://www.primevideo.com/-/de/detail/0JYKQR8R1TDGMZGKZVLH13HP8E
+imdbID: tt6038600
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=bM_-W5Vo48o
+tags:
+  - Mobile
+  - App Store
+  - Indie
+  - Software Development
+description: A revealing look at the forces behind the screen that have made mobile devices into a paradigm-shifting phenomenon - the developers, designers, and dreamers who turned the App Store into a cultural and economic force.

--- a/movies/google-and-the-world-brain.yml
+++ b/movies/google-and-the-world-brain.yml
@@ -1,0 +1,12 @@
+name: Google and the World Brain
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=gIUa4FkGaq4
+imdbID: tt2551516
+tags:
+  - Google
+  - Copyright
+  - Internet
+  - Society
+description: The most ambitious project ever conceived on the Internet - Google's effort to scan every book in the world - sparked an unprecedented backlash from writers, publishers, librarians and policy makers around the globe. The documentary tells the story of the secret pact, the worldwide revolt, and the future of the world's knowledge.

--- a/movies/insert-coin.yml
+++ b/movies/insert-coin.yml
@@ -1,0 +1,28 @@
+name: Insert Coin
+type: Documentary
+category: Culture / People
+links:
+  youtube: https://www.youtube.com/watch?v=7zx5GunyUS4
+  amazon_prime_video: https://www.primevideo.com/-/de/detail/Insert-Coin/0SP3M4H5YLMETO27UKMKDBP7SY
+imdbID: tt12128566
+language:
+  - en
+  - de
+tags:
+  - Gaming
+  - Arcade
+  - History
+  - Midway
+description: >-
+  Insert Coin is the behind-the-scenes story of one of the greatest
+  video game studios of all time - Midway Games. Led by the
+  "Godfather of Videogames" Eugene Jarvis, the company pioneered the
+  concept of live action gaming, kickstarting a new arcade boom and
+  grossing billions of dollars in the process with massive hits like
+  Mortal Kombat and NBA Jam. Through intimate and often hilarious
+  interviews with the people who were there, we witness how a small,
+  tight-knit group of friends deal with next level success and the
+  roller coaster ride that comes with it.
+localized:
+  de:
+    description: Die Dokumentation erzählt die Geschichte eines Teams von Nerds und Außenseitern, die in einer Fabrik in Chicago die größten Videospiele aller Zeiten entwickelten. Midway Games war Vorreiter des Live-Action-Gamings, löste damit einen neuen Arcade-Boom aus und erzielte mit Hits wie Mortal Kombat und NBA Jam Milliardenumsätze. Die Dokumentation beleuchtet einen Großteil der Geschichte von Mortal Kombat, darunter die Entwicklung der Fatalities und Charaktere wie Liu Kang, Kitana, Johnny Cage und Scorpion.

--- a/movies/kill-chain-the-cyber-war-on-americas-elections.yml
+++ b/movies/kill-chain-the-cyber-war-on-americas-elections.yml
@@ -1,0 +1,14 @@
+name: "Kill Chain: The Cyber War on America's Elections"
+type: Documentary
+category: Culture / Society
+links:
+  amazon_prime_video: https://www.primevideo.com/-/de/detail/0HJLOZ49TEBBAPIZEJI2PDWGC1/
+  hbo_max: https://www.hbomax.com/tr/en/movies/kill-chain-the-cyber-war-on-americas-elections/f8e375c7-3758-4570-b8a4-3e938db44898
+imdbID: tt11865098
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=AwSVN_dgio8
+tags:
+  - Security
+  - Elections
+  - Hacking
+  - Politics
+description: Finnish hacker and election expert Harri Hursti investigates election-related hacks, uncovering just how unprotected voting systems really are.

--- a/movies/risk.yml
+++ b/movies/risk.yml
@@ -1,0 +1,13 @@
+name: Risk
+type: Documentary
+category: Culture / People
+links:
+  youtube: https://www.youtube.com/watch?v=mq9q3lOCJQ0
+  netflix: https://www.netflix.com/title/80117236
+imdbID: tt5566410
+tags:
+  - WikiLeaks
+  - Whistleblowing
+  - Privacy
+  - Journalism
+description: What happens when radical transparency collides with state secrets? Risk is a gripping documentary by Laura Poitras that takes you inside the world of WikiLeaks, Julian Assange, and the global fight over information, power, and truth.

--- a/movies/zero-days.yml
+++ b/movies/zero-days.yml
@@ -1,0 +1,20 @@
+name: Zero Days
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=F8l_eIGU_H8
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.faab71cc-b891-ac52-2485-42fbcf36405f
+  apple_tv: https://tv.apple.com/de/movie/zero-days---world-war-30/umc.cmc.4oquioo4lz0w050igaffx92ri
+imdbID: tt5446858
+language:
+  - en
+  - de
+tags:
+  - Security
+  - Cyberwarfare
+  - Stuxnet
+  - Politics
+description: A documentary focused on Stuxnet, a self-replicating computer virus discovered in 2010 to be undermining Iran's nuclear program, and the men and women who tried to contain its fallout.
+localized:
+  de:
+    title: Zero Days - World War 3.0


### PR DESCRIPTION
## Summary

Adds six new entries:

- **Insert Coin** — Midway Games / Mortal Kombat / NBA Jam.
- **Google and the World Brain** — the global pushback against Google Books.
- **Risk** — Laura Poitras' second Assange / WikiLeaks documentary.
- **Kill Chain: The Cyber War on America's Elections** — Harri Hursti on voting-machine security.
- **Zero Days** — Stuxnet.
- **App: The Human Story** — the human side of the App Store.

Also broadens the **HBO Max** detector. The Kill Chain URL is `hbomax.com/tr/en/movies/...`, which exposed two gaps in the original detector: it required the catalogue segment to sit at the path root, and it only recognised the singular `/movie/` form. Switched the segment checks to `strings.Contains` and added `/movies/` + `/series/`.

## Test plan

- [x] `go test ./...` is green; new platform test case for the locale-prefixed `hbomax.com/tr/en/movies/...` URL passes.
- [x] `convertYamlToJson` over `movies/` runs cleanly with no slug/URL mismatch warnings.
- [ ] CI's `yaml-lint`, `render-readme`, and `testing` workflows pass.
- [ ] After merge, the next `movie-data` enrichment run pulls thumbnails / channel info / IMDb ratings for the new entries.

Note: depends on PR #29 (HBO Max / Apple TV / RTL+ slugs); raw slugs would render in the README until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)