### PR TITLE
Add Hollywood style category and 9 scripted entries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,12 +40,16 @@ Out of scope for now:
 - Conference talks unless they are explicitly long-form / documentary
   in nature.
 - Content with no English audio and no English subtitles.
-- Purely fictional movies / TV series — invented characters and
-  plots, even with a tech setting (e.g. *Mr. Robot*, *Halt and
-  Catch Fire*, cyber-thrillers). Biopics and dramatised true
-  stories about real engineers or real events (e.g. *The Social
-  Network*, *Pirates of Silicon Valley*) ARE in scope; use
-  `type: Movie` for those.
+- Plot-driven cyber-thrillers without a real-world tech-culture
+  anchor (e.g. *Mr. Robot*, *Halt and Catch Fire*) — the focus is
+  on the thriller plot, not on engineering culture. Biopics and
+  dramatised true stories about real engineers or real events
+  (e.g. *The Social Network*, *Pirates of Silicon Valley*,
+  *The Imitation Game*) and scripted comedies / dramas that are
+  recognisably about software-engineering culture (e.g. HBO's
+  *Silicon Valley*, *The IT Crowd*) ARE in scope; use
+  `type: Movie` or `type: TV Series` and
+  `category: Hollywood style` for those.
 
 ## How to add an entry
 
@@ -93,7 +97,7 @@ non-commercial dataset.
 | `language`    | list[string]   | no       | YAML > API      | ISO 639-1 codes (`en`, `de`, `fr`, …). If omitted, the tooling falls back to the YouTube `defaultAudioLanguage` and stores it as a single-element list. Set it manually when the API returns nothing or when the video has multiple audio languages. |
 | `description` | string         | no       | YAML > API      | Free text. If omitted, the tooling uses the video's YouTube description. Set it manually when the YouTube description is empty, full of unrelated boilerplate, or otherwise unhelpful for skim-reading the README. |
 | `tags`        | list[string]   | yes      | YAML            | Subject-matter tags. Be coarse — better to have 3–5 broad tags than 15 narrow ones. |
-| `category`    | string         | yes      | YAML            | Coarse subject classification. One of: `Programming Languages`, `Culture / Society`, `Culture / People`, `Applications / Frameworks / Systems`. Complementary to `tags` (one classification, several subject tags). The tooling warns on values outside the set but keeps them. |
+| `category`    | string         | yes      | YAML            | Coarse subject classification. One of: `Programming Languages`, `Culture / Society`, `Culture / People`, `Applications / Frameworks / Systems`, `Hollywood style`. Complementary to `tags` (one classification, several subject tags). The tooling warns on values outside the set but keeps them. |
 | `type`        | string         | yes      | YAML            | Format classification. One of: `Documentary`, `Movie`, `TV Series`. Same warn-but-keep semantics as `category`. |
 | `imdbID`      | string         | no       | YAML            | IMDb tconst (e.g. `tt3268458`). Set this only when the entry is also catalogued on IMDb so the tooling can pull the IMDb rating from the public dataset. Most YouTube documentaries are not on IMDb — leave this unset for those. |
 | `localized`   | map[code → object] | no   | YAML            | Per-language alternate-version overrides. Keys are ISO 639-1 codes (`de`, `es`, …). Each value supports optional `title`, `description`, and `links` (same shape as the top-level `links` map) — provide whichever differs from the English top-level. The `links` override is per-key: only the platform slugs you list override their top-level counterparts; every other top-level platform is inherited unchanged. Alternate links are not enriched (no extra YouTube/IMDb API calls); they round-trip from YAML to JSON unchanged. |

--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -189,6 +189,7 @@ var validCategories = []string{
 	"Culture / Society",
 	"Culture / People",
 	"Applications / Frameworks / Systems",
+	"Hollywood style",
 }
 
 // validTypes enumerates the format classifications a curated entry

--- a/movies/23.yml
+++ b/movies/23.yml
@@ -1,0 +1,34 @@
+name: "23"
+type: Movie
+category: Hollywood style
+links:
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.3e7449a8-4bd6-409b-a1b0-56fc2762b43c
+  apple_tv: https://tv.apple.com/de/movie/23/umc.cmc.1n7aar1t57m6rndfhm9u6vixo
+  youtube: https://www.youtube.com/watch?v=e2DCvHZGGH4
+imdbID: tt0126765
+language:
+  - en
+  - de
+tags:
+  - Hacking
+  - History
+  - Conspiracy
+  - Cold War
+description: >-
+  Nineteen-year-old Karl is fascinated by the fictional character
+  Hagbard Celine and sets out to uncover the inner workings of
+  political mechanisms. He discovers things that lead him to believe
+  in a conspiracy. Karl's talent for hacking into global data
+  networks and his unshakeable belief in justice drive him into the
+  arms of the KGB. He loses control.
+localized:
+  de:
+    title: 23 - Nichts ist so wie es scheint
+    description: >-
+      Der 19-jährige Karl ist fasziniert von der fiktiven Romanfigur
+      Hagbard Celine und macht sich auf die Suche nach den
+      Hintergründen politischer Mechanismen. Er entdeckt Dinge, die
+      ihn an eine Verschwörung glauben lassen. Karls Begabung, sich
+      in globale Datennetze einzuklinken, und sein unerschütterlicher
+      Glaube an die Gerechtigkeit, treiben ihn in die Arme des KGBs.
+      Er verliert die Kontrolle.

--- a/movies/hidden-figures.yml
+++ b/movies/hidden-figures.yml
@@ -1,0 +1,47 @@
+name: Hidden Figures
+type: Movie
+category: Hollywood style
+links:
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.8ab8c01b-a530-5865-60bc-eeedf40e97b4
+  apple_tv: https://tv.apple.com/de/movie/hidden-figures---unerkannte-heldinnen/umc.cmc.4io2m0zk1cs9g1olb2hduzu6z
+  youtube: https://www.youtube.com/watch?v=bvAbdZbHmhY
+imdbID: tt4846340
+language:
+  - en
+  - de
+tags:
+  - NASA
+  - History
+  - Mathematics
+  - Diversity
+description: >-
+  "Hidden Figures" is the incredible, untold story of Katherine
+  Johnson, Dorothy Vaughan, and Mary Jackson. It is a passionate
+  tribute to three extraordinary African American women who worked at
+  NASA in the early 1960s and played a leading role in one of the
+  most significant events in recent history. These brilliant
+  mathematicians are part of the team that enables the first U.S.
+  astronaut, John Glenn, to orbit the Earth. A breathtaking
+  achievement that gives the American nation new self-confidence,
+  redefines the space race, and stirs the world. In doing so, the
+  visionary trio fights to overcome gender and racial barriers and
+  serves as an inspiration for future generations to hold fast to
+  their big dreams.
+localized:
+  de:
+    title: Hidden Figures - Unerkannte Heldinnen
+    description: >-
+      Hidden Figures - Unerkannte Heldinnen ist die bisher noch nicht
+      erzählte, unglaubliche Geschichte von Katherine Johnson, Dorothy
+      Vaughn und Mary Jackson. Eine leidenschaftliche Hommage an drei
+      herausragende afroamerikanische Frauen, die zu Beginn der
+      sechziger Jahre bei der NASA arbeiten und an vorderster Front an
+      einem der wichtigsten Ereignisse der jüngeren Zeitgeschichte
+      beteiligt sind. Die brillanten Mathematikerinnen sind Teil jenes
+      Teams, das dem ersten US-Astronauten John Glenn die Erdumrundung
+      ermöglicht. Eine atemberaubende Leistung, die der amerikanischen
+      Nation neues Selbstbewusstsein gibt, den Wettlauf ins All neu
+      definiert und die Welt aufrüttelt. Dabei kämpft das visionäre
+      Trio um die Überwindung der Geschlechter- und Rassengrenzen und
+      ist eine Inspiration für kommende Generationen, an ihren großen
+      Träumen festzuhalten.

--- a/movies/pirates-of-silicon-valley.yml
+++ b/movies/pirates-of-silicon-valley.yml
@@ -1,0 +1,37 @@
+name: Pirates of Silicon Valley
+type: Movie
+category: Hollywood style
+links:
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.a6ad7e6d-dcf5-32fa-e147-1589b9f9ec4a
+imdbID: tt0168122
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=yG4DvM0wxdk
+language:
+  - en
+  - de
+tags:
+  - Apple
+  - Microsoft
+  - History
+  - Startups
+description: >-
+  On the cusp of the digital age, visionary geniuses Bill Gates and
+  Steve Jobs launch the revolutionary race between rivals Microsoft
+  and Apple Computer. From late-night tinkering sessions in the dorm
+  to days spent strategizing in the boardroom - their fierce and
+  often humorous battle to dominate the fledgling computer industry
+  gives rise to a new technology that literally changes the world.
+  Based on the book *Fire in the Valley* by Paul Freiberger and
+  Michael Swaine.
+localized:
+  de:
+    title: Die Silicon Valley Story
+    description: >-
+      An der Schwelle des digitalen Zeitalters starten visionäre
+      Genies Bill Gates und Steve Jobs das revolutionäre Rennen
+      zwischen den Rivalen Microsoft und Apple Computer. Von
+      Bastel-Nächten im Studentenwohnheim zu Tagen voller
+      Pläneschmieden im Sitzungssaal - ihr wilder und oft
+      humorvoller Kampf, die junge Computer-Industrie zu regieren,
+      schafft eine neue Technologie, die buchstäblich die Welt
+      verändert. In Anlehnung an das Buch Fire in the Valley von
+      Paul Freiberger und Michael Swaine.

--- a/movies/silicon-valley.yml
+++ b/movies/silicon-valley.yml
@@ -1,0 +1,35 @@
+name: Silicon Valley
+type: TV Series
+category: Hollywood style
+links:
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.4cd6c5b9-d3e2-4c54-af1b-a73875c38357
+  apple_tv: https://tv.apple.com/de/season/season-1/umc.cmc.2e1pibwq8h4w470jrt2j5aw01?showId=umc.cmc.4v7y09m6sa22lpe3bqomh27a
+  youtube: https://www.youtube.com/show/SC2L5QE7tgqHgriBrZQBfT4g
+imdbID: tt2575988
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=Vm4tx1O9GAc
+language:
+  - en
+  - de
+tags:
+  - Startups
+  - Comedy
+  - Satire
+  - Tech Industry
+description: >-
+  Silicon Valley is a critically acclaimed HBO comedy series
+  (2014-2019) created by Mike Judge that parodies the tech boom. It
+  follows Richard Hendricks, an introverted programmer, and his
+  friends as they struggle to launch a startup called Pied Piper while
+  navigating, and often failing at, the ruthless, cutthroat culture of
+  Silicon Valley.
+localized:
+  de:
+    description: >-
+      „Silicon Valley" ist eine von Kritikern hochgelobte
+      HBO-Comedy-Serie (2014-2019) von Mike Judge, die den Tech-Boom
+      parodiert. Die Serie handelt von Richard Hendricks, einem
+      introvertierten Programmierer, und seinen Freunden, die sich
+      abmühen, ein Start-up namens Pied Piper auf die Beine zu
+      stellen, während sie sich in der rücksichtslosen, gnadenlosen
+      Kultur des Silicon Valley zurechtfinden müssen - und dabei oft
+      scheitern.

--- a/movies/snowden.yml
+++ b/movies/snowden.yml
@@ -1,0 +1,35 @@
+name: Snowden
+type: Movie
+category: Hollywood style
+links:
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.2088b418-e12c-4a0d-b569-8542561d890d
+  apple_tv: https://tv.apple.com/de/movie/snowden/umc.cmc.3j73epo0sky4mob3jog0xxw5r
+  youtube: https://www.youtube.com/watch?v=0l78qbhP3QU
+imdbID: tt3774114
+language:
+  - en
+  - de
+tags:
+  - Surveillance
+  - Privacy
+  - Whistleblowing
+  - NSA
+description: >-
+  Traitor or hero. What would you do if you knew your government was
+  abusing the power entrusted to it? How far would your resistance
+  go? What sacrifices would you be willing to make? Snowden, the
+  international thriller from Oscar® winner Oliver Stone, brings the
+  life of the controversial whistleblower Edward Snowden to the big
+  screen. The story of an ordinary man who could not reconcile his
+  conscience with remaining silent...
+localized:
+  de:
+    description: >-
+      Verräter oder Held. Was würden Sie tun, wenn Sie wüssten, dass
+      Ihre Regierung die ihr verliehene Macht missbraucht? Wie weit
+      würde Ihr Widerstand gehen? Welche Opfer wären Sie bereit zu
+      erbringen? Snowden, der internationale Thriller von
+      Oscar®-Preisträger Oliver Stone, bringt das Leben des
+      kontrovers diskutierten Whistleblowers Edward Snowden auf die
+      Kinoleinwand. Die Geschichte eines normalen Mannes, der es
+      nicht mit seinem Gewissen vereinbaren konnte, zu schweigen...

--- a/movies/steve-jobs.yml
+++ b/movies/steve-jobs.yml
@@ -1,0 +1,38 @@
+name: Steve Jobs
+type: Movie
+category: Hollywood style
+links:
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.08a9f70b-7712-cd47-4e13-d0e9613e58dd
+  apple_tv: https://tv.apple.com/de/movie/steve-jobs/umc.cmc.20qugmesej4yg33x3e4uev8xh
+  youtube: https://www.youtube.com/watch?v=wPqfVEOCIqE
+imdbID: tt2080374
+language:
+  - en
+  - de
+tags:
+  - Apple
+  - Biopic
+  - Product Launches
+description: >-
+  "Steve Jobs" is an authentic biopic about the man behind the
+  digital revolution. The film reveals what went on behind the
+  scenes in the days leading up to the Apple CEO's most significant
+  product launches. A compelling portrayal that shows the unique
+  visionary from a side never seen before! Written by Oscar® winner
+  Aaron Sorkin ("The Social Network") and directed by Oscar® winner
+  Danny Boyle ("Slumdog Millionaire"), the drama shines with an
+  impressive star-studded cast, including: Michael Fassbender, Kate
+  Winslet, Seth Rogen, and Jeff Daniels.
+localized:
+  de:
+    description: >-
+      „Steve Jobs" ist ein authentisches Biopic über den Mann hinter
+      der digitalen Revolution. Der Film enthüllt, was sich kurz vor
+      den bedeutendsten Produktpräsentationen des Apple-Chefs hinter
+      den Kulissen abspielte. Eine eindrucksvolle Darstellung, die
+      den einzigartigen Visionär von einer noch nie zuvor gesehenen
+      Seite zeigt! Aus der Feder von Oscar®-Preisträger Aaron Sorkin
+      („The Social Network") und unter der Regie von
+      Oscar®-Preisträger Danny Boyle („Slumdog Millionaire") glänzt
+      das Drama mit beeindruckender Starbesetzung, darunter: Michael
+      Fassbender, Kate Winslet, Seth Rogen und Jeff Daniels.

--- a/movies/the-imitation-game.yml
+++ b/movies/the-imitation-game.yml
@@ -1,0 +1,54 @@
+name: The Imitation Game
+type: Movie
+category: Hollywood style
+links:
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.9ea9f6d8-dcfc-e49d-ffea-c3f92245045d
+  apple_tv: https://tv.apple.com/de/movie/the-imitation-game---ein-streng-geheimes-leben/umc.cmc.59i1cp4fboyedvyq6zlx3bymd
+  youtube: https://www.youtube.com/watch?v=Kauqv7p-8b4
+imdbID: tt2084970
+language:
+  - en
+  - de
+tags:
+  - Cryptography
+  - History
+  - WWII
+  - Alan Turing
+description: >-
+  The Enigma is giving researchers a headache: the German coding
+  machine encrypts the radio messages of the Wehrmacht and the Navy.
+  Mathematicians and other researchers at Bletchley Park in Britain
+  are working around the clock to crack the German code. Finally, a
+  young genius, Alan Turing (Benedict Cumberbatch), achieves a
+  breakthrough - from then on, the German radio messages are no
+  longer a secret to the Allies. Now, however, the task is to make
+  this breakthrough the country's best-kept secret. Only in this way
+  can the Germans be prevented from deploying a new encryption
+  system. Turing becomes a celebrated star. But he, too, has a secret
+  that must not fall into the wrong hands: he is gay. An "offense"
+  that, in Britain at that time, is punishable by imprisonment and
+  chemical castration. His superior, MI6/SIS chief Stewart Menzies
+  (Mark Strong), in particular, views his most important keeper of
+  secrets with suspicion and is unwilling to tolerate even the
+  slightest sign of weakness.
+localized:
+  de:
+    title: The Imitation Game - Ein streng geheimes Leben
+    description: >-
+      Die Enigma zerbricht den Forschern den Kopf: Das deutsche
+      Kodiergerät verschlüsselt die Funksprüche der Wehrmacht und
+      Marine. Mit Hochdruck arbeiten Mathematiker und andere Forscher
+      im britischen Bletchley Park daran, den deutschen Code zu
+      knacken. Schließlich gelingt einem jungen Genie, Alan Turing
+      (Benedict Cumberbatch), der Durchbruch - die deutschen
+      Funksprüche sind fortan kein Geheimnis mehr für die Alliierten.
+      Jetzt gilt es jedoch, diesen Fortschritt zum bestgehüteten
+      Geheimnis des Landes zu machen. Nur so kann verhindert werden,
+      dass die Deutschen eine neue Verschlüsselung einsetzen. Turing
+      wird zum gefeierten Star. Doch auch er hat ein Geheimnis, das
+      nicht an falsche Ohren gelangen darf: Er ist homosexuell. Ein
+      "Vergehen", das im Großbritannien dieser Tage mit Haftstrafen
+      und chemischen Kastrationen geahndet wird. Besonders sein
+      Vorgesetzter, der MI6/SIS-Chef Stewart Menzies (Mark Strong),
+      blickt mit Misstrauen auf seinen wichtigsten Geheimnisträger und
+      ist nicht bereit, das leiseste Zeichen von Schwäche zu dulden.

--- a/movies/the-it-crowd.yml
+++ b/movies/the-it-crowd.yml
@@ -1,0 +1,33 @@
+name: The IT Crowd
+type: TV Series
+category: Hollywood style
+links:
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/B00IB0EEG2/
+  apple_tv: https://tv.apple.com/de/season/season-1/umc.cmc.6eshvcv6fxiwz658zv0krognk?showId=umc.cmc.14z35ywo1dbp5e81sh0yj6520
+imdbID: tt0487831
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=rksCTVFtjM4
+language:
+  - en
+  - de
+tags:
+  - Comedy
+  - Workplace
+  - Sitcom
+  - British
+description: >-
+  Moss and Roy, two computer experts, eke out a miserable existence in
+  the basement of Reynholm Industries. Their colleagues hold them in
+  low regard, so they've grown quite gruff in their dealings with
+  others. It isn't until they get a new boss, Jen, that their daily
+  lives start to pick up again. Is this attractive young woman the key
+  to helping these two nerds escape their obscurity?
+localized:
+  de:
+    description: >-
+      Die beiden Computerfachmänner Moss und Roy fristen ihr trauriges
+      Arbeitsleben im Keller der Firma Reynholm Industries. Sie werden
+      von ihren Kollegen wenig geachtet und haben sich deshalb
+      mittlerweile eine recht ruppige Umgangsform angewöhnt. Erst als
+      sie mit Jen eine neue Vorgesetzte erhalten, kommt wieder Schwung
+      in ihren Alltag. Ist die attraktive junge Frau der Weg aus der
+      Bedeutungslosigkeit für die beiden Nerds?

--- a/movies/underground-the-julian-assange-story.yml
+++ b/movies/underground-the-julian-assange-story.yml
@@ -1,0 +1,43 @@
+name: "Underground: The Julian Assange Story"
+type: Movie
+category: Hollywood style
+links:
+  amazon_prime_video: https://www.amazon.de/gp/video/detail/amzn1.dv.gti.62a9f6d2-5a7c-57e0-e99b-dd258248554c
+  youtube: https://www.youtube.com/watch?v=b5z86SpPHU0
+imdbID: tt2357453
+language:
+  - en
+  - de
+tags:
+  - Hacking
+  - WikiLeaks
+  - Biopic
+  - History
+description: >-
+  Julian Assange became a legend in his own lifetime for making
+  highly sensitive classified information available to the entire
+  world. But what does the world really know about him? Underground:
+  The Julian Assange Story traces the early days of the WikiLeaks
+  founder. This fascinating film is based on Suelette Dreyfus's 1997
+  book about a community of computer hackers. It sheds light on what
+  kind of person Julian Assange is. It depicts his arrest for hacking
+  into a Canadian telephone company. Particularly striking are his
+  early days as a hacker, breaking into the Pentagon, the U.S. Army,
+  and NASA. All these actions have made him one of the most
+  controversial figures of our time.
+localized:
+  de:
+    title: "Underground: Die Julian Assange Story"
+    description: >-
+      Julian Assange wurde schon zu Lebzeiten zur Legende, weil er
+      höchstbrisante Geheiminformationen der ganzen Welt zugänglich
+      gemacht hat. Aber was weiß die Welt über ihn? Underground: The
+      Julian Assange Story zeigt die Anfänge des Wikileaks-Gründers.
+      Der faszinierende Film beruht auf dem 1997 erschienenen Buch
+      von Suelette Dreyfus über eine Gemeinschaft von Computerhackern.
+      Er macht deutlich, was für ein Mensch Julian Assange ist. Er
+      zeigt seine Verhaftung wegen des Eindringens bei einer
+      kanadischen Telefonfirma. Besonders eindrucksvoll sind seine
+      Anfänge als Hacker mit dem Eindringen im Pentagon, der US Army
+      und der NASA. All dies Taten, die ihn zu einer der
+      kontroversesten Figuren unserer Zeit gemacht haben.


### PR DESCRIPTION
## Summary

- Introduce a new `Hollywood style` category for scripted/dramatised productions, distinct from the documentary-heavy existing catalogue. Allow-listed in `app/cmd/convertYamlToJson.go` and documented in `CONTRIBUTING.md`.
- Narrow the "purely fictional" out-of-scope rule in `CONTRIBUTING.md`: plot-driven cyber-thrillers (Mr. Robot, Halt and Catch Fire) remain out of scope, but scripted productions that are recognisably about software-engineering culture (HBO's *Silicon Valley*, *The IT Crowd*, biopics) are now in scope under the new category.
- Add 9 entries under `Hollywood style`:
  - **TV Series:** The IT Crowd, Silicon Valley (HBO)
  - **Movies (biopics & dramatised true stories):** Hidden Figures, The Imitation Game, Snowden, 23, Pirates of Silicon Valley, Steve Jobs, Underground: The Julian Assange Story
- Each entry has English top-level + German `localized.de` (title where it differs, description). IMDb IDs set so the next `collectMovieData` run pulls ratings.

## Test plan

- [x] `go build ./... && go test ./...` from `app/` — pass
- [x] `convertYamlToJson` runs over `movies/` without errors; three advisory warnings remain for Apple TV `/season/` URLs and a YouTube `/show/` URL (detector currently recognises only `/movie/`, `/show/`, `/episode/` on Apple TV) — YAML flows through unchanged, can be addressed separately by extending `app/platform/platform.go`
- [ ] CI: `yaml-lint`, `render-readme`, `testing` workflows
- [ ] Spot-check rendered README for the new "Hollywood style" grouping after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)