### PR TITLE
Add 4 documentaries on piracy, hacker conferences and BBS history

### DIFF
--- a/movies/bbs-the-documentary.yml
+++ b/movies/bbs-the-documentary.yml
@@ -1,0 +1,20 @@
+name: "BBS: The Documentary"
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/playlist?list=PL7nj3G6Jpv2G6Gp6NvN1kUtQuW8QshBWE
+youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=nO5vjmDFZaI
+language:
+  - en
+tags:
+  - Internet History
+  - BBS
+  - Online Communities
+  - Modems
+description: >-
+  Through eight episodes, director Jason Scott covers the 25 year
+  history of the Dial-Up Bulletin Board System, a modem-connected
+  computer system that let others connect to a computer over a
+  phone line and leave messages and trade files. Containing 200
+  interviews, episodes mostly consist of elaborate montages of
+  dozens of people composing a narrative.

--- a/movies/defcon-the-documentary.yml
+++ b/movies/defcon-the-documentary.yml
@@ -1,0 +1,19 @@
+name: "DEFCON: The Documentary"
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=3ctQOmjQyYg
+imdbID: tt3010462
+language:
+  - en
+tags:
+  - Hacking
+  - Security
+  - Conferences
+  - Community
+description: >-
+  A film about the world's largest hacking convention and its 20th
+  year running. Filmed over the summer of 2012 and containing
+  hundreds of hours of interviews, parties, presentations and
+  spectacle. Over 280 hours of footage was recorded in support of
+  the documentary, and five separate camera crews were in action.

--- a/movies/good-copy-bad-copy.yml
+++ b/movies/good-copy-bad-copy.yml
@@ -1,0 +1,19 @@
+name: Good Copy Bad Copy
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=ByY6j0qzOyM
+imdbID: tt1782451
+language:
+  - en
+tags:
+  - Copyright
+  - File Sharing
+  - Internet Culture
+  - Remix
+description: >-
+  A documentary about the current state of copyright and culture, is
+  a documentary about copyright and culture in the context of
+  Internet, peer-to-peer file sharing and other technological
+  advances, directed by Andreas Johnsen, Ralf Christensen, and
+  Henrik Moltke.

--- a/movies/steal-this-film.yml
+++ b/movies/steal-this-film.yml
@@ -1,0 +1,17 @@
+name: Steal This Film
+type: Documentary
+category: Culture / Society
+links:
+  youtube: https://www.youtube.com/watch?v=YJ2Fh3tAD-I
+imdbID: tt1422757
+language:
+  - en
+tags:
+  - File Sharing
+  - Copyright
+  - BitTorrent
+  - Internet Culture
+description: >-
+  Steal This Film is part one of a series, documenting the movement
+  against intellectual property produced by The League of Noble Peers
+  and released via the BitTorrent peer-to-peer protocol.


### PR DESCRIPTION
## Summary

Curated batch of four English-language documentaries covering corners of internet / software-engineering culture not yet in the catalogue:

- **Steal This Film** (2006) — League of Noble Peers' BitTorrent-distributed film on the anti-IP movement
- **Good Copy Bad Copy** (2007) — copyright and culture in the age of P2P
- **DEFCON: The Documentary** (2013) — the world's largest hacker conference in its 20th year
- **BBS: The Documentary** (2005) — Jason Scott's 8-episode history of the Dial-Up Bulletin Board System era

All `type: Documentary`, `category: Culture / Society`. IMDb IDs included where available so the next `collectMovieData` run pulls ratings.

## Test plan

- [x] `convertYamlToJson` runs over `movies/` cleanly for the four new entries
- [x] One advisory warning on BBS — its primary YouTube link is the 8-episode playlist, and the platform detector does not recognise playlist URLs. YAML round-trips unchanged; `youtubeTrailerForThumbnail` points at a single trailer video so the README still renders a poster.
- [ ] CI: `yaml-lint`, `render-readme`, `testing` workflows
- [ ] Spot-check rendered README after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)