### PR TITLE
Prefer curated trailer URL when downloading thumbnails

### DIFF
--- a/app/cmd/collectMovieData.go
+++ b/app/cmd/collectMovieData.go
@@ -385,9 +385,13 @@ const placeholderImage = "images/placeholder.svg"
 
 // populateThumbnail fills info.Image using a layered fallback:
 //
-//  1. Primary YouTube link (info.VideoID).
-//  2. Curated YouTube trailer URL (info.YouTubeTrailerForThumbnail).
+//  1. Curated YouTube trailer URL (info.YouTubeTrailerForThumbnail).
+//  2. Primary YouTube link (info.VideoID).
 //  3. Bundled placeholder SVG when the entry has no other image.
+//
+// The curated trailer takes precedence so a maintainer can override
+// the auto-derived poster when the primary video's thumbnail is
+// missing or unrepresentative.
 //
 // The cache-keep semantic from the previous implementation is
 // preserved: if every YouTube candidate fails but info.Image is
@@ -395,9 +399,6 @@ const placeholderImage = "images/placeholder.svg"
 // alone. The placeholder is only chosen when there is nothing else.
 func populateThumbnail(info *MovieInformation, imageDir string) {
 	var candidates []string
-	if info.VideoID != "" {
-		candidates = append(candidates, info.VideoID)
-	}
 	if info.YouTubeTrailerForThumbnail != "" {
 		if id, ok := youtube.ParseVideoID(info.YouTubeTrailerForThumbnail); ok {
 			candidates = append(candidates, id)
@@ -405,6 +406,9 @@ func populateThumbnail(info *MovieInformation, imageDir string) {
 			log.Printf("WARNING: %s: youtubeTrailerForThumbnail %q is not a YouTube URL; ignoring",
 				info.Name, info.YouTubeTrailerForThumbnail)
 		}
+	}
+	if info.VideoID != "" {
+		candidates = append(candidates, info.VideoID)
 	}
 
 	for _, id := range candidates {

--- a/app/cmd/types.go
+++ b/app/cmd/types.go
@@ -79,12 +79,13 @@ type MovieInformation struct {
 	// Drives the IMDb rating lookup in collectMovieData; entries
 	// without it never trigger an IMDb dataset download.
 	IMDbID string `yaml:"imdbID,omitempty"      json:"imdbID,omitempty"`
-	// YouTubeTrailerForThumbnail is an optional YouTube URL used as
-	// a fallback source for the entry's poster. When the primary
-	// link is not a YouTube video (or the YouTube thumbnail download
-	// fails), the tooling extracts the video ID from this URL and
-	// pulls hqdefault.jpg / maxresdefault.jpg via the i.ytimg.com
-	// URL pattern. If neither path yields an image, the README
+	// YouTubeTrailerForThumbnail is an optional YouTube URL that
+	// overrides the auto-derived poster for the entry. When set, the
+	// tooling extracts the video ID from this URL and pulls
+	// hqdefault.jpg / maxresdefault.jpg via the i.ytimg.com URL
+	// pattern in preference to the primary YouTube link's thumbnail.
+	// The primary link's video ID is still tried as a fallback if
+	// this URL fails to yield an image; if both fail, the README
 	// renders a bundled placeholder.
 	YouTubeTrailerForThumbnail string `yaml:"youtubeTrailerForThumbnail,omitempty" json:"youtubeTrailerForThumbnail,omitempty"`
 	// Duration is optional in YAML; format is ISO-8601 like the YouTube


### PR DESCRIPTION
## Summary
- `populateThumbnail` now tries `youtubeTrailerForThumbnail` before the primary `links.youtube` video ID, so the curated override actually takes effect when both fields are set.
- Previously the curated trailer was a *fallback* that almost never ran (YouTube's `hqdefault.jpg` is guaranteed to exist for any public video), defeating the field's intent.
- Doc comments on the field (`app/cmd/types.go`) and on `populateThumbnail` (`app/cmd/collectMovieData.go`) updated to reflect the new precedence. No schema or YAML changes.

## Test plan
- [x] `go build ./...` in `app/`
- [ ] Pick an entry with both `links.youtube` and `youtubeTrailerForThumbnail` set, delete its cached image under `generated/images/`, re-run the collect command, and confirm the new thumbnail matches the trailer video ID.
- [ ] Sanity-check an entry with only `links.youtube` and one with only `youtubeTrailerForThumbnail` — both should still produce thumbnails.
- [ ] `git diff generated/` after a full run shows only the intended image changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)