### PR TITLE
Abort YouTube API calls on daily quota exhaustion

### DIFF
--- a/app/youtube/quota.go
+++ b/app/youtube/quota.go
@@ -1,0 +1,53 @@
+package youtube
+
+import (
+	"errors"
+	"log"
+	"time"
+
+	"google.golang.org/api/googleapi"
+)
+
+// IsQuotaExceeded reports whether err is a YouTube Data API daily-quota
+// exhaustion error (HTTP 403 with reason "quotaExceeded"). It does not
+// match the short-window rateLimitExceeded / userRateLimitExceeded
+// reasons — those clear within seconds and warrant retry, not abort.
+func IsQuotaExceeded(err error) bool {
+	var ge *googleapi.Error
+	if !errors.As(err, &ge) {
+		return false
+	}
+	if ge.Code != 403 {
+		return false
+	}
+	for _, e := range ge.Errors {
+		if e.Reason == "quotaExceeded" {
+			return true
+		}
+	}
+	return false
+}
+
+// nextQuotaReset returns the next time the YouTube Data API daily quota
+// will refill. The API documents quota as resetting at midnight Pacific
+// Time. The error response itself does not advertise a Retry-After or
+// reset timestamp, so we compute it from the documented schedule.
+func nextQuotaReset() time.Time {
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		loc = time.UTC
+	}
+	now := time.Now().In(loc)
+	return time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, loc)
+}
+
+// logQuotaExceeded emits a single warning describing which API hit the
+// daily quota wall and when the quota is expected to refill. The
+// YouTube error payload itself does not carry a reset timestamp, so the
+// "lifts at" value is derived from the documented midnight-Pacific
+// reset schedule.
+func logQuotaExceeded(api string, err error) {
+	reset := nextQuotaReset()
+	log.Printf("WARNING: youtube: %s daily quota exceeded; aborting further YouTube API calls. Quota resets at %s (in ~%s). Original error: %v",
+		api, reset.Format(time.RFC1123), time.Until(reset).Round(time.Minute), err)
+}

--- a/app/youtube/videos.go
+++ b/app/youtube/videos.go
@@ -47,6 +47,13 @@ const videosListMaxIDs = 50
 // IDs that the API does not return (private, deleted, region-blocked)
 // are simply absent from the result — the caller decides how to
 // handle that.
+//
+// If any call hits the daily quotaExceeded error, the function logs
+// the expected quota-reset time once and stops issuing further YouTube
+// API requests for the remainder of this invocation. Whatever video
+// records were already collected are returned with a nil error so
+// downstream passes (thumbnails, IMDb, README) can still run on the
+// partial data.
 func (c *Client) GetVideoDetails(ctx context.Context, ids []string) ([]Video, error) {
 	if len(ids) == 0 {
 		return nil, nil
@@ -55,12 +62,17 @@ func (c *Client) GetVideoDetails(ctx context.Context, ids []string) ([]Video, er
 	var out []Video
 	parts := []string{"snippet", "contentDetails", "statistics"}
 
+batchLoop:
 	for start := 0; start < len(ids); start += videosListMaxIDs {
 		end := min(start+videosListMaxIDs, len(ids))
 
 		call := c.svc.Videos.List(parts).Id(ids[start:end]...).Context(ctx)
 		resp, err := call.Do()
 		if err != nil {
+			if IsQuotaExceeded(err) {
+				logQuotaExceeded("videos.list", err)
+				break batchLoop
+			}
 			return nil, fmt.Errorf("youtube: videos.list: %w", err)
 		}
 
@@ -93,6 +105,11 @@ func (c *Client) GetVideoDetails(ctx context.Context, ids []string) ([]Video, er
 			// the total quota stays well within the daily budget.
 			subs, err := c.GetCaptionLanguages(ctx, v.ID)
 			if err != nil {
+				if IsQuotaExceeded(err) {
+					logQuotaExceeded("captions.list", err)
+					out = append(out, v)
+					break batchLoop
+				}
 				log.Printf("WARNING: youtube: captions.list for %s failed: %v; leaving subtitles empty", v.ID, err)
 			} else {
 				v.Subtitles = subs


### PR DESCRIPTION
## Summary
- Detect `quotaExceeded` (HTTP 403, `googleapi.Error.Errors[].Reason == "quotaExceeded"`) inside `GetVideoDetails` and stop issuing further `videos.list` / `captions.list` calls for the rest of the run instead of triggering one identical warning per remaining video.
- Return the partial slice of `Video` records gathered before the quota wall with `nil` error, so downstream passes (thumbnails, IMDb, README) still run on whatever was collected.
- The `quotaExceeded` response carries no reset timestamp, so log the next midnight Pacific Time (the API's documented daily-quota refill) plus the time remaining, so the operator knows when re-running is safe. Short-window `rateLimitExceeded` / `userRateLimitExceeded` reasons are intentionally not matched.

## Motivation
A recent run produced a flood like:
```
Fetching video details for 55 ID(s) from YouTube ...
WARNING: youtube: captions.list for YJ2Fh3tAD-I failed: ... quotaExceeded ...
WARNING: youtube: captions.list for LB8KwiiUGy0 failed: ... quotaExceeded ...
WARNING: youtube: captions.list for S4J9e7W68g4 failed: ... quotaExceeded ...
...
```
Every one of those calls still contributes to Google's rate-limit window even though it is doomed. The new behaviour stops at the first quota error, logs once, and tells the operator when the quota lifts.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Manually verify behaviour by temporarily forcing a 403 quotaExceeded response (e.g. revoking the key) and confirming a single warning with the reset time, no further API calls, and the rest of the pipeline still completing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)