### PR TITLE
Skip video-ID parse warning for YouTube show and playlist URLs

### DIFF
--- a/app/cmd/collectMovieData.go
+++ b/app/cmd/collectMovieData.go
@@ -126,7 +126,10 @@ func cmdCollectMovieData(cmd *cobra.Command, args []string) error {
 		if id, ok := youtube.ParseVideoID(ytURL); ok {
 			info.VideoID = id
 			ids = append(ids, id)
-		} else {
+		} else if !youtube.IsNonVideoURL(ytURL) {
+			// Show and playlist URLs are legitimate catalogue entries
+			// that simply do not map to a single video; warning on
+			// them would be noise.
 			log.Printf("WARNING: could not parse YouTube video ID from %q in %s", ytURL, absJsonFilePath)
 		}
 	}

--- a/app/youtube/url.go
+++ b/app/youtube/url.go
@@ -43,3 +43,29 @@ func ParseVideoID(rawURL string) (string, bool) {
 
 	return "", false
 }
+
+// IsNonVideoURL reports whether rawURL is a recognised YouTube URL
+// that intentionally does not point at a single video — currently
+// playlist URLs (/playlist?list=…) and show URLs (/show/…). Callers
+// use this to skip "could not parse video ID" warnings for entries
+// that legitimately reference a series or playlist instead of a
+// single video.
+func IsNonVideoURL(rawURL string) bool {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(u.Host) {
+	case "youtube.com", "www.youtube.com", "m.youtube.com":
+	default:
+		return false
+	}
+	path := strings.Trim(u.Path, "/")
+	if path == "playlist" {
+		return true
+	}
+	if strings.HasPrefix(path, "show/") {
+		return true
+	}
+	return false
+}

--- a/app/youtube/url_test.go
+++ b/app/youtube/url_test.go
@@ -33,3 +33,27 @@ func TestParseVideoID(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNonVideoURL(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"playlist", "https://www.youtube.com/playlist?list=PL7nj3G6Jpv2G6Gp6NvN1kUtQuW8QshBWE", true},
+		{"playlist_no_www", "https://youtube.com/playlist?list=PLabc", true},
+		{"show", "https://www.youtube.com/show/SC2L5QE7tgqHgriBrZQBfT4g", true},
+		{"video_watch", "https://www.youtube.com/watch?v=uaksVVHDhYU", false},
+		{"video_short", "https://youtu.be/uaksVVHDhYU", false},
+		{"non_youtube", "https://vimeo.com/12345", false},
+		{"empty", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsNonVideoURL(tc.input); got != tc.want {
+				t.Fatalf("IsNonVideoURL(%q) = %v; want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Recognise YouTube show (`/show/<id>`) and playlist (`/playlist?list=<id>`) URLs as legitimate non-video catalogue links via a new `youtube.IsNonVideoURL` helper.
- Suppress the `WARNING: could not parse YouTube video ID from …` log line for those two URL shapes in the collect command. The URL is still excluded from the `videos.list` batch (there is no video ID to fetch); it just no longer screams about it.
- Other unrecognised YouTube paths continue to warn so genuine typos still surface.

## Motivation
A recent run produced:
```
WARNING: could not parse YouTube video ID from "https://www.youtube.com/show/SC2L5QE7tgqHgriBrZQBfT4g" in ../generated/silicon-valley.json
WARNING: could not parse YouTube video ID from "https://www.youtube.com/playlist?list=PL7nj3G6Jpv2G6Gp6NvN1kUtQuW8QshBWE" in ../generated/bbs-the-documentary.json
```
Both URLs are intentional: Silicon Valley is a TV series with a YouTube show page, and the BBS documentary is published as a playlist of episodes. Warning on those misleads readers into thinking the YAML is broken.

## Test plan
- [x] `go test ./youtube/...` (added cases for show, playlist, video, non-YouTube, empty)
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)