### PR TITLE
Add IMDb IDs to BBS, Half-Life 25th, and Python documentaries

### DIFF
--- a/movies/bbs-the-documentary.yml
+++ b/movies/bbs-the-documentary.yml
@@ -3,6 +3,7 @@ type: Documentary
 category: Culture / Society
 links:
   youtube: https://www.youtube.com/playlist?list=PL7nj3G6Jpv2G6Gp6NvN1kUtQuW8QshBWE
+imdbID: tt0460402
 youtubeTrailerForThumbnail: https://www.youtube.com/watch?v=nO5vjmDFZaI
 language:
   - en

--- a/movies/half-life-25th-anniversary-documentary.yml
+++ b/movies/half-life-25th-anniversary-documentary.yml
@@ -3,6 +3,7 @@ type: Documentary
 category: Culture / Society
 links:
   youtube: https://www.youtube.com/watch?v=TbZ3HzvFEto
+imdbID: tt30060427
 tags:
   - Game Development
   - Valve

--- a/movies/python-the-documentary.yml
+++ b/movies/python-the-documentary.yml
@@ -3,6 +3,7 @@ type: Documentary
 category: Programming Languages
 links:
   youtube: https://www.youtube.com/watch?v=GfH4QL4VqJ0
+imdbID: tt38589263
 tags:
   - Programming Languages
   - Open Source


### PR DESCRIPTION
## Summary
- Three movie YAMLs in `movies/` lacked an `imdbID`, so the collect command's IMDb-rating pass silently skipped them. Add the IDs for the three entries that do have a verified IMDb listing.
- Verified each ID via IMDb URL match (`https://www.imdb.com/title/<id>/`):
  - `bbs-the-documentary.yml` → `tt0460402` (BBS: The Documentary, 2005)
  - `half-life-25th-anniversary-documentary.yml` → `tt30060427` (Half-Life: 25th Anniversary Documentary, 2023)
  - `python-the-documentary.yml` → `tt38589263` (Python: the Documentary, 2025)
- The other 22 YAMLs without `imdbID` are Honeypot / OfferZen / CultRepo YouTube productions with no IMDb listing; they stay as-is and continue to skip the IMDb pass.

## Notes
- IMDb classifies BBS: The Documentary as a TV Series. The repo currently has it as `type: Documentary`. Left unchanged here — that is a separate editorial decision.

## Test plan
- [ ] On the next `collectMovieData` run, confirm the three entries gain IMDb ratings in their generated JSON / README rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)