### PR TITLE
Reclassify six entries to better-fitting categories

### DIFF
--- a/movies/countdown-inspiration4-mission-to-space.yml
+++ b/movies/countdown-inspiration4-mission-to-space.yml
@@ -1,6 +1,6 @@
 name: "Countdown: Inspiration4 Mission to Space"
 type: Documentary
-category: Culture / Society
+category: Culture / People
 links:
   netflix: https://www.netflix.com/title/81441273
 imdbID: tt15679706

--- a/movies/half-life-25th-anniversary-documentary.yml
+++ b/movies/half-life-25th-anniversary-documentary.yml
@@ -1,6 +1,6 @@
 name: "Half-Life: 25th Anniversary Documentary"
 type: Documentary
-category: Culture / Society
+category: Culture / People
 links:
   youtube: https://www.youtube.com/watch?v=TbZ3HzvFEto
 imdbID: tt30060427

--- a/movies/indie-game-the-movie.yml
+++ b/movies/indie-game-the-movie.yml
@@ -1,6 +1,6 @@
 name: "Indie Game: The Movie"
 type: Documentary
-category: Culture / Society
+category: Culture / People
 links:
   netflix: https://www.netflix.com/title/70229918
 imdbID: tt1942884

--- a/movies/print-the-legend.yml
+++ b/movies/print-the-legend.yml
@@ -1,6 +1,6 @@
 name: Print the Legend
 type: Documentary
-category: Culture / Society
+category: Culture / People
 links:
   netflix: https://www.netflix.com/title/80005444
   apple_tv: https://tv.apple.com/de/movie/print-the-legend/umc.cmc.4ca9o2wed84i5ptt1fccfu91o

--- a/movies/the-billion-dollar-code.yml
+++ b/movies/the-billion-dollar-code.yml
@@ -1,6 +1,6 @@
 name: The Billion Dollar Code
 type: TV Series
-category: Culture / People
+category: Hollywood style
 links:
   netflix: https://www.netflix.com/title/81074012
 imdbID: tt15392936

--- a/movies/the-king-of-kong-a-fistful-of-quarters.yml
+++ b/movies/the-king-of-kong-a-fistful-of-quarters.yml
@@ -1,6 +1,6 @@
 name: "The King of Kong: A Fistful of Quarters"
 type: Documentary
-category: Culture / Society
+category: Culture / People
 links:
   youtube: https://www.youtube.com/watch?v=lXLQqcHcJDQ
 imdbID: tt0923752


### PR DESCRIPTION
## Summary
Six entries in `movies/` had a `category` that did not match the entry's actual subject relative to the discriminators documented in `CONTRIBUTING.md`. Updating each to the better-fitting value:

| Entry | From | To |
|---|---|---|
| The Billion Dollar Code | Culture / People | **Hollywood style** |
| Indie Game: The Movie | Culture / Society | **Culture / People** |
| The King of Kong: A Fistful of Quarters | Culture / Society | **Culture / People** |
| Countdown: Inspiration4 Mission to Space | Culture / Society | **Culture / People** |
| Half-Life: 25th Anniversary Documentary | Culture / Society | **Culture / People** |
| Print the Legend | Culture / Society | **Culture / People** |

## Rationale
- **The Billion Dollar Code** is a scripted Netflix drama; `CONTRIBUTING.md` is explicit that scripted dramatisations (cf. *Silicon Valley*, *The IT Crowd*) belong in `Hollywood style`.
- The remaining five are protagonist-driven documentaries built around named individuals (developers, founders, crew, dev teams) rather than broad societal themes. That is the discriminator the existing corpus already uses between `Culture / People` and `Culture / Society`.

## Out of scope
- The category audit also flagged `BBS: The Documentary` (type vs IMDb classification) and the `Kubernetes: The Documentary` PART 1 / PART 2 split. Those are structural/editorial decisions and are intentionally not part of this PR.

## Test plan
- [ ] Skim the regenerated README on next collect run and confirm the six entries appear under their new sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)