### PR TITLE
Add Spring: The Documentary entry

### DIFF
--- a/movies/spring-the-documentary.yml
+++ b/movies/spring-the-documentary.yml
@@ -1,0 +1,10 @@
+name: "Spring: The Documentary"
+type: Documentary
+category: Applications / Frameworks / Systems
+links:
+  youtube: https://www.youtube.com/watch?v=0Gb1z-2SjHY
+tags:
+  - Web Frameworks
+  - Java
+  - Open Source
+  - History


### PR DESCRIPTION
## Summary
- Adds `movies/spring-the-documentary.yml` for the documentary about the Spring Java framework (https://www.youtube.com/watch?v=0Gb1z-2SjHY).
- Tags follow the pattern set by the other backend-web-framework documentaries (Laravel Origins, Ruby on Rails: The Documentary): `[Web Frameworks, Java, Open Source, History]`.
- Remaining metadata (title, description, duration, publishedAt, channel, views, ratings, thumbnail) will be enriched by the next monthly `movie-data` run via the YouTube Data API.

## Test plan
- [ ] `yaml-lint` workflow passes
- [ ] `render-readme` workflow renders the entry under *Applications / Frameworks / Systems*
- [ ] `testing` workflow passes
- [ ] After merge, next `movie-data` run enriches the JSON with YouTube metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)