### PR TITLE
ci: Configure git identity before rebase in push retry

### DIFF
--- a/.github/workflows/movie-data.yml
+++ b/.github/workflows/movie-data.yml
@@ -59,6 +59,13 @@ jobs:
           commit_author: "GitHub Actions Bot <actions@github.com>"
           skip_push: true
 
+      - name: Configure git identity for rebase
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
       - name: Push changes with retry
         if: steps.auto-commit.outputs.changes_detected == 'true'
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
## Summary

- Adds a `Configure git identity for rebase` step between the auto-commit step and the `Push changes with retry` retry loop in `.github/workflows/movie-data.yml`.
- Sets repo-level `user.name`/`user.email` to the same values already advertised on `stefanzweifel/git-auto-commit-action` (`GitHub Actions Bot <actions@github.com>`), so `git pull --rebase` inside the retry loop has a committer identity to replay commits with.

## Why

The retry loop introduced to handle concurrent pushes to `main` calls `git pull --rebase origin main`. Rebase needs a committer identity in git config. `stefanzweifel/git-auto-commit-action` only sets identity inline for its own `git commit` (via `git -c …`) and does not persist it, so the next shell step starts without one and aborts with:

```
Committer identity unknown
fatal: empty ident name (for <runner@...>) not allowed
```

Same root cause and fix as EngineeringKiosk/awesome-software-engineering-games#53.

## Test plan

- [ ] Merge to `main`.
- [ ] Trigger `Movie data` via `workflow_dispatch` from the Actions tab.
- [ ] Confirm the new `Configure git identity for rebase` step runs (or is skipped when no changes were detected).
- [ ] Confirm `Push changes with retry` succeeds without the `empty ident name` error, including in the rebase path if a concurrent push lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)